### PR TITLE
Return the entire traceback when an error is encountered.

### DIFF
--- a/src/plone/jsonapi/core/browser/decorators.py
+++ b/src/plone/jsonapi/core/browser/decorators.py
@@ -8,6 +8,7 @@ __docformat__ = 'plaintext'
 import time
 import logging
 import simplejson as json
+import traceback
 from helpers import error
 
 logger = logging.getLogger("plone.jsonapi")
@@ -21,8 +22,9 @@ def handle_errors(f):
         try:
             return f(*args, **kwargs)
         # XXX we should create a custom Exception class
-        except Exception, e:
-            return error(str(e))
+        except Exception:
+            tb = traceback.format_exc()
+            return error(str(tb))
     return decorator
 
 


### PR DESCRIPTION
This catches me quite often.  I use jsonapi in my own product, to expose several functions.  When a user sends strange parameters in the request, an error is returned such as "{u'runtime': 0.007885932922363281, u'success': False, u'error': u'list index out of range'}" - this is not enough information for me to fix the error.

I know that printing the entire \n-separated traceback is not pretty, but it certainly makes my life easier, and I hope that you can include this in the next release...
