### PR TITLE
Fixed virtualhost bug with JSON URLs.

### DIFF
--- a/src/plone/jsonapi/core/browser/router.py
+++ b/src/plone/jsonapi/core/browser/router.py
@@ -6,6 +6,7 @@ __author__ = 'Ramon Bartl <ramon.bartl@googlemail.com>'
 __docformat__ = 'plaintext'
 
 import logging
+from urlparse import urlsplit
 
 from zope import component
 from werkzeug.routing import Map, Rule
@@ -36,7 +37,7 @@ class Router(object):
         self.request = request
 
         self.environ = request.environ
-        self.http_host = request["HTTP_HOST"]
+        self.http_host = urlsplit(request["ACTUAL_URL"]).netloc
         self.url = request.getURL()
 
         if self.is_initialized:


### PR DESCRIPTION
I didn't see the fix in the 'develop' branch until I created my own.  This approach is slightly simpler using the named tuple instead of get_hostname method added in the develop branch.  

Regardless of approach, it would be good to get one of these changes committed to the master branch.

