### PR TITLE
Add APIError hierarchy and IErrorHandler interface

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -2,6 +2,12 @@ Changelog
 =========
 
 
+0.8.0 (unreleased)
+------------------
+
+- #29 Add APIError hierarchy and IErrorHandler interface
+
+
 0.7.0 - 2020-03-29
 ------------------
 

--- a/src/plone/jsonapi/core/browser/exceptions.py
+++ b/src/plone/jsonapi/core/browser/exceptions.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+"""Typed exception classes for the JSON API framework.
+
+Every JSON API consumer used to invent its own exception class, then
+map it to the right HTTP status in an ad-hoc handler. The classes
+here give the framework a single shared hierarchy so downstream code
+(bika.lims.jsonapi, senaite.jsonapi, custom integrations) can just
+`raise NotFoundError("...")` and have the framework surface the
+correct status and a stable `type` field to clients.
+
+`APIError` is the base class. Every subclass carries a default HTTP
+status; callers can override it per instance with `status=`.
+Backward compatibility: any `except APIError:` handler catches every
+subclass.
+"""
+
+__author__ = "Ramon Bartl <rb@ridingbytes.com>"
+__docformat__ = "plaintext"
+
+
+class APIError(Exception):
+    """Base class for every JSON API error.
+
+    Carries an HTTP status and a human-facing message. The framework
+    error handler uses `.status` to set the response status and
+    `type(exc).__name__` to populate the envelope's `type` field.
+    """
+    status = 500
+
+    def __init__(self, message, status=None):
+        if status is not None:
+            self.status = status
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+
+class BadRequestError(APIError):
+    """400 - the request is malformed or missing required fields."""
+    status = 400
+
+
+class UnauthorizedError(APIError):
+    """401 - the caller is not authenticated.
+
+    Distinct from `ForbiddenError`: 401 means "log in and try again",
+    403 means "you are logged in but you may not do this".
+    """
+    status = 401
+
+
+class ForbiddenError(APIError):
+    """403 - the caller is authenticated but lacks permission."""
+    status = 403
+
+
+class NotFoundError(APIError):
+    """404 - the addressed resource does not exist."""
+    status = 404
+
+
+class MethodNotAllowedError(APIError):
+    """405 - the resource does not accept this HTTP method."""
+    status = 405
+
+
+class ConflictError(APIError):
+    """409 - the request conflicts with the current resource state."""
+    status = 409
+
+
+class ValidationError(APIError):
+    """422 - the payload is well-formed but semantically invalid."""
+    status = 422

--- a/src/plone/jsonapi/core/browser/interfaces.py
+++ b/src/plone/jsonapi/core/browser/interfaces.py
@@ -3,7 +3,7 @@
 from zope import interface
 
 
-__author__ = "Ramon Bartl <ramon.bartl@googlemail.com>"
+__author__ = "Ramon Bartl <rb@ridingbytes.com>"
 __docformat__ = "plaintext"
 
 
@@ -36,4 +36,22 @@ class IRouteProvider(interface.Interface):
     def routes(self):
         """ needs to return a tuple of tuples containing
             rule, endpoint, view_func and additional options
+        """
+
+
+class IErrorHandler(interface.Interface):
+    """Renders an exception raised by a JSON API route into the
+    response envelope.
+
+    Registered as an unnamed utility. Consumers can register their
+    own utility to customize the envelope (extra fields, i18n,
+    hiding internals in production, ...) without monkey-patching
+    the decorator.
+    """
+
+    def __call__(exc, request):
+        """Return the JSON-ready dict for the given exception.
+
+        The utility is responsible for setting the HTTP response
+        status on `request.response`.
         """

--- a/src/plone/jsonapi/core/tests/test_exceptions.py
+++ b/src/plone/jsonapi/core/tests/test_exceptions.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+"""Unit tests for the APIError hierarchy.
+
+Pins the class layout (base + typed subclasses, default status codes,
+message/status behavior) so refactors don't silently change the shape
+downstream consumers depend on.
+"""
+
+import unittest2 as unittest
+
+from plone.jsonapi.core.browser.exceptions import APIError
+from plone.jsonapi.core.browser.exceptions import BadRequestError
+from plone.jsonapi.core.browser.exceptions import ConflictError
+from plone.jsonapi.core.browser.exceptions import ForbiddenError
+from plone.jsonapi.core.browser.exceptions import MethodNotAllowedError
+from plone.jsonapi.core.browser.exceptions import NotFoundError
+from plone.jsonapi.core.browser.exceptions import UnauthorizedError
+from plone.jsonapi.core.browser.exceptions import ValidationError
+
+
+class TestAPIErrorHierarchy(unittest.TestCase):
+
+    def test_every_typed_error_subclasses_APIError(self):
+        # Any `except APIError:` handler must catch every subclass so
+        # downstream code that predates the hierarchy keeps working.
+        for cls in (BadRequestError, UnauthorizedError, ForbiddenError,
+                    NotFoundError, MethodNotAllowedError, ConflictError,
+                    ValidationError):
+            self.assertTrue(
+                issubclass(cls, APIError),
+                "{} must inherit from APIError".format(cls.__name__))
+
+    def test_default_status_per_subclass(self):
+        self.assertEqual(APIError.status, 500)
+        self.assertEqual(BadRequestError.status, 400)
+        self.assertEqual(UnauthorizedError.status, 401)
+        self.assertEqual(ForbiddenError.status, 403)
+        self.assertEqual(NotFoundError.status, 404)
+        self.assertEqual(MethodNotAllowedError.status, 405)
+        self.assertEqual(ConflictError.status, 409)
+        self.assertEqual(ValidationError.status, 422)
+
+    def test_message_survives_str(self):
+        self.assertEqual(str(NotFoundError("no such thing")), "no such thing")
+
+    def test_explicit_status_overrides_class_default(self):
+        err = ForbiddenError("nope", status=451)
+        self.assertEqual(err.status, 451)
+
+    def test_message_attribute_is_set(self):
+        err = ValidationError("bad payload")
+        self.assertEqual(err.message, "bad payload")
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestAPIErrorHierarchy))
+    return suite


### PR DESCRIPTION
## Summary

Ships a shared exception hierarchy so downstream JSON API consumers (bika.lims.jsonapi, senaite.jsonapi, custom integrations) no longer have to invent their own `APIError` class and ad-hoc HTTP-status mapping. This PR is purely additive; nothing wires the classes in yet — the actual behavior change (swappable error handler + envelope with `type` field) lands in the follow-up #upstream/swappable-handler.

## What this PR adds

**`browser/exceptions.py`** — new module:

| Class | Default status | Use for |
|---|---|---|
| `APIError` | 500 | base class |
| `BadRequestError` | 400 | malformed payload, missing required field |
| `UnauthorizedError` | 401 | caller is anonymous |
| `ForbiddenError` | 403 | authenticated but lacks permission |
| `NotFoundError` | 404 | resource does not exist |
| `MethodNotAllowedError` | 405 | resource does not accept this method |
| `ConflictError` | 409 | request conflicts with current state |
| `ValidationError` | 422 | payload well-formed but semantically invalid |

Callers can override the status per instance with `status=`; every subclass inherits `APIError` so any `except APIError:` handler catches every one.

**`browser/interfaces.py`** — adds `IErrorHandler` interface. Empty registration point; the default handler lands in the next PR in the stack.

**Tests** — `tests/test_exceptions.py` pins the hierarchy shape, default status per class, message/status behavior, and the `except APIError` catches-everything contract.

## Backward compatibility

Purely additive. No existing name, signature, or behavior is changed.

## Stack

1. **This PR — APIError hierarchy** (base for the rest)
2. Swappable error handler with clean envelope and status flow
3. Convert Router match failures and no-router-matched to typed 404/405
4. Add opt-in CORS support

Merge in order top-to-bottom.