### PR TITLE
Swappable error handler with clean envelope and status flow

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -5,6 +5,7 @@ Changelog
 0.8.0 (unreleased)
 ------------------
 
+- #30 Swappable error handler with clean envelope and status flow
 - #29 Add APIError hierarchy and IErrorHandler interface
 
 

--- a/src/plone/jsonapi/core/browser/configure.zcml
+++ b/src/plone/jsonapi/core/browser/configure.zcml
@@ -18,4 +18,11 @@
         provides=".interfaces.IRouter"
         factory=".router.DefaultRouterFactory" />
 
+    <!-- The default error handler. Consumers can override this
+         utility to replace the JSON error envelope shape without
+         monkey-patching handle_errors. -->
+    <utility
+        provides=".interfaces.IErrorHandler"
+        component=".decorators.default_error_handler" />
+
 </configure>

--- a/src/plone/jsonapi/core/browser/decorators.py
+++ b/src/plone/jsonapi/core/browser/decorators.py
@@ -1,33 +1,79 @@
 # -*- coding: utf-8 -*-
 
+import logging
 import os
 import time
-import traceback
 
 import dicttoxml
 import simplejson as json
 from ZPublisher.Iterators import filestream_iterator
+from zope.component import queryUtility
 
+from .exceptions import APIError  # noqa: F401  re-exported
 from .helpers import error
+from .interfaces import IErrorHandler
 
-__author__ = "Ramon Bartl <ramon.bartl@googlemail.com>"
+__author__ = "Ramon Bartl <rb@ridingbytes.com>"
 __docformat__ = "plaintext"
+
+logger = logging.getLogger("plone.jsonapi.core.decorators")
 
 
 def handle_errors(f):
-    """ simple JSON error handler
+    """JSON error handler for API routes.
+
+    Delegates envelope construction to the IErrorHandler utility so
+    consumers can plug their own without monkey-patching. The default
+    utility (`default_error_handler`) logs the full traceback and
+    returns `{success: False, message: str(exc), type: <class>}` with
+    the appropriate HTTP status set on the response.
     """
 
-    def decorator(*args, **kwargs):
+    def decorator(instance, *args, **kwargs):
         try:
-            return f(*args, **kwargs)
-        # XXX we should create a custom Exception class
-        except Exception as e:
-            # Print out the exception to the console
-            traceback.print_exc()
-            return error(str(e))
+            return f(instance, *args, **kwargs)
+        except Exception as exc:
+            request = getattr(instance, "request", None)
+            handler = queryUtility(IErrorHandler)
+            if handler is None:
+                handler = default_error_handler
+            return handler(exc, request)
 
     return decorator
+
+
+def default_error_handler(exc, request):
+    """Default IErrorHandler implementation.
+
+    Logs the full traceback server-side (never in the response body)
+    and returns an envelope carrying:
+
+    - `success`: False (kept for backward compatibility with
+      pre-typed-exceptions clients)
+    - `message`: `str(exc)` - the exception's human-facing message,
+      no stack frames
+    - `type`: the exception's class name so clients can distinguish
+      error kinds without parsing free-form text (CWE-209 fix: the
+      previous implementation put `traceback.format_exc()` in
+      `message`, exposing file paths and code structure).
+
+    HTTP response status comes from `exc.status` when the exception
+    is an APIError (or any object exposing a `status` int); 500
+    otherwise. Bare `Exception` implies nothing about intent, so 500
+    is the correct default.
+    """
+    logger.exception("JSON API error: %s", exc)
+
+    status = getattr(exc, "status", None)
+    if not isinstance(status, int):
+        status = 500
+
+    if request is not None:
+        response = getattr(request, "response", None)
+        if response is not None:
+            response.setStatus(status)
+
+    return error(str(exc), type=type(exc).__name__)
 
 
 def runtime(func):

--- a/src/plone/jsonapi/core/tests/test_error_handler.py
+++ b/src/plone/jsonapi/core/tests/test_error_handler.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+
+"""Unit tests for the swappable error handler.
+
+Covers the default_error_handler in isolation and the handle_errors
+decorator behavior. The full Plone fixture is not needed for these
+paths; the decorator only touches request.response.setStatus.
+"""
+
+import unittest2 as unittest
+
+from plone.jsonapi.core.browser.decorators import default_error_handler
+from plone.jsonapi.core.browser.decorators import handle_errors
+from plone.jsonapi.core.browser.exceptions import APIError
+from plone.jsonapi.core.browser.exceptions import NotFoundError
+
+
+class FakeResponse(object):
+    def __init__(self):
+        self.status = None
+
+    def setStatus(self, status):
+        self.status = status
+
+
+class FakeRequest(object):
+    def __init__(self):
+        self.response = FakeResponse()
+
+
+class TestDefaultErrorHandler(unittest.TestCase):
+
+    def test_message_is_the_exception_message_only(self):
+        request = FakeRequest()
+        result = default_error_handler(ValueError("visible"), request)
+        self.assertEqual(result["message"], "visible")
+        self.assertFalse(result["success"])
+
+    def test_no_traceback_leaks_into_message(self):
+        # Regression: pre-refactor default put format_exc() in message.
+        request = FakeRequest()
+        result = default_error_handler(RuntimeError("boom"), request)
+        self.assertNotIn("Traceback", result["message"])
+        self.assertNotIn("File \"", result["message"])
+        self.assertNotIn("line ", result["message"])
+
+    def test_type_field_is_exception_class_name(self):
+        request = FakeRequest()
+        result = default_error_handler(KeyError("missing"), request)
+        self.assertEqual(result["type"], "KeyError")
+
+    def test_status_from_APIError_subclass(self):
+        request = FakeRequest()
+        default_error_handler(NotFoundError("gone"), request)
+        self.assertEqual(request.response.status, 404)
+
+    def test_status_defaults_to_500_for_bare_exception(self):
+        request = FakeRequest()
+        default_error_handler(RuntimeError("boom"), request)
+        self.assertEqual(request.response.status, 500)
+
+    def test_explicit_status_on_APIError_wins(self):
+        request = FakeRequest()
+        default_error_handler(APIError("teapot", status=418), request)
+        self.assertEqual(request.response.status, 418)
+
+    def test_no_request_context_does_not_crash(self):
+        # Unit tests and setup handlers may raise without a request.
+        result = default_error_handler(NotFoundError("gone"), None)
+        self.assertEqual(result["message"], "gone")
+
+
+class TestHandleErrorsDecorator(unittest.TestCase):
+
+    def _fake_view(self):
+        class View(object):
+            request = FakeRequest()
+        return View()
+
+    def test_successful_call_passes_through(self):
+        view = self._fake_view()
+
+        @handle_errors
+        def ok(self):
+            return {"success": True, "items": [1, 2, 3]}
+
+        self.assertEqual(ok(view), {"success": True, "items": [1, 2, 3]})
+
+    def test_APIError_produces_envelope_with_type_and_status(self):
+        view = self._fake_view()
+
+        @handle_errors
+        def raiser(self):
+            raise NotFoundError("no widget")
+
+        result = raiser(view)
+        self.assertEqual(result["message"], "no widget")
+        self.assertEqual(result["type"], "NotFoundError")
+        self.assertFalse(result["success"])
+        self.assertEqual(view.request.response.status, 404)
+
+    def test_bare_exception_produces_500(self):
+        view = self._fake_view()
+
+        @handle_errors
+        def raiser(self):
+            raise RuntimeError("boom")
+
+        result = raiser(view)
+        self.assertEqual(result["type"], "RuntimeError")
+        self.assertEqual(view.request.response.status, 500)
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestDefaultErrorHandler))
+    suite.addTest(makeSuite(TestHandleErrorsDecorator))
+    return suite


### PR DESCRIPTION
## Summary

Rewrites `handle_errors` so it delegates envelope construction to the `IErrorHandler` utility. The default implementation (`default_error_handler`) logs the traceback server-side, returns a clean envelope with a new `type` field, and sets the HTTP response status from the exception. Consumers that need a different envelope shape (extra fields, i18n, hiding internals in production, ...) can register their own `IErrorHandler` utility instead of monkey-patching the decorator.

## Depends on

#29 (APIError hierarchy). Merge that first.

## The security-relevant part

The previous `handle_errors` implementation:

1. Called `traceback.print_exc()` to stdout on every exception (log spam in production, and the traceback ends up in wherever stdout is captured — often shared logs).
2. Stuffed `traceback.format_exc()` **into the JSON response body** as the `message` field, exposing file paths, function names and code structure to any caller that could trigger an exception.

That is CWE-209 (information exposure through an error message). This PR:

- Logs the traceback via `logging.getLogger(...).exception(...)` — operator visibility is unchanged, no more stdout noise.
- Returns only `str(exc)` as `message` — the exception's own human-facing message, no stack frames.
- Adds a `type` field carrying `type(exc).__name__` so clients can distinguish error kinds without parsing free-form text.

## HTTP status flow

Response status is now derived from the exception:

- `exc.status` when the exception has an integer `.status` attribute (any `APIError` subclass, or duck-typed objects)
- 500 otherwise

Previously every error came out as HTTP 200 unless the exception itself set the response status as a side effect during construction.

## Swappable

`handle_errors` now looks up `IErrorHandler` on the ZCA registry. The unnamed utility wins. `default_error_handler` is registered in `configure.zcml`; consumers override by registering their own `IErrorHandler`.

This is what makes it possible for downstream consumers (bika.lims.jsonapi, senaite.jsonapi) to stop monkey-patching `plone.jsonapi.core.browser.decorators.handle_errors` — they can just register their own `IErrorHandler` utility.

## Backward compatibility

- Envelope keys `success` and `message` are preserved — clients that only read those still work.
- `type` is purely additive.
- `APIError` is re-exported from `decorators.py` so the old `from ...decorators import APIError` import path keeps working.

## Coverage

`tests/test_error_handler.py` covers:

- `default_error_handler`: message is `str(exc)` only, no traceback in body, `type` is the class name, status flows from `.status`, defaults to 500, explicit status wins, no-request path doesn't crash.
- `handle_errors` decorator: successful call passes through, `APIError` produces the envelope with `type` + status, bare exception produces 500.

## Stack

1. Add APIError hierarchy and IErrorHandler interface
2. **This PR — swappable handler + clean envelope**
3. Convert Router match failures and no-router-matched to typed 404/405
4. Add opt-in CORS support