### PR TITLE
Convert Router match failures and no-router-matched to typed 404/405

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -5,6 +5,7 @@ Changelog
 0.8.0 (unreleased)
 ------------------
 
+- #31 Convert Router match failures and no-router-matched to typed 404/405
 - #30 Swappable error handler with clean envelope and status flow
 - #29 Add APIError hierarchy and IErrorHandler interface
 

--- a/src/plone/jsonapi/core/browser/api.py
+++ b/src/plone/jsonapi/core/browser/api.py
@@ -5,6 +5,8 @@ from .decorators import returns_binary_stream
 from .decorators import returns_json
 from .decorators import returns_xml
 from .decorators import runtime
+from .exceptions import APIError
+from .exceptions import NotFoundError
 from .interfaces import IAPI
 from .interfaces import IRouter
 from Products.Five import BrowserView
@@ -39,16 +41,35 @@ class API(BrowserView):
         return self
 
     def dispatch(self):
-        """ dispatches the given subpath to the router
+        """Dispatch the given subpath to the first matching router.
+
+        Router.match raises NotFoundError / MethodNotAllowedError when
+        the path or method does not resolve; earlier versions returned
+        None silently, which surfaced as an empty 200 response. Try
+        each registered router in turn; the first successful match
+        wins. Only the last router's error is reraised, so ordering
+        matters when multiple routers are registered.
         """
         path = "/".join(self.traverse_subpath)
         logger.debug("Dispatching path: '%s'", path)
+
+        last_error = None
         for name, router in component.getUtilitiesFor(IRouter):
             router.initialize(self.context, self.request)
-            # The first router which is able to match the route wins.
-            if router.match(self.context, self.request, path):
+            try:
+                match = router.match(self.context, self.request, path)
+            except APIError as exc:
+                last_error = exc
+                continue
+            if match:
                 logger.debug("Router '%r' will handle the request", router)
                 return router(self.context, self.request, path)
+
+        # No router matched: reraise the most-recent match failure, or
+        # a bare NotFoundError if none of the routers even threw.
+        if last_error is not None:
+            raise last_error
+        raise NotFoundError("No route matches {}".format(path))
 
     @returns_json
     @runtime

--- a/src/plone/jsonapi/core/browser/router.py
+++ b/src/plone/jsonapi/core/browser/router.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 
+from .exceptions import MethodNotAllowedError
+from .exceptions import NotFoundError
 from .interfaces import IRouteProvider
 from six.moves.urllib.parse import urlsplit
+from werkzeug.exceptions import MethodNotAllowed as WzMethodNotAllowed
+from werkzeug.exceptions import NotFound as WzNotFound
 from werkzeug.routing import Map
 from werkzeug.routing import Rule
 from zope import component
@@ -103,16 +107,27 @@ class Router(object):
         return adapter
 
     def match(self, context, request, path):
-        """ url matcher
+        """Werkzeug URL matcher.
 
-        default options:
-        (path_info=None, method=None, return_rule=False, query_args=None)
-        see: http://werkzeug.pocoo.org/docs/routing/#werkzeug.routing.MapAdapter.match
+        Werkzeug raises `NotFound` when no rule matches and
+        `MethodNotAllowed` when the path matches but the method
+        doesn't. Both used to propagate out of `handle_errors` as
+        HTTP 500 with an unhelpful body; convert them to proper
+        typed API errors (404 / 405) so the client sees the right
+        status.
         """
         method = request.environ.get("REQUEST_METHOD", "GET")
         logger.debug("router.match: method=%s" % method)
         adapter = self.get_adapter(path_info=path)
-        endpoint, values = adapter.match(method=method)
+        try:
+            endpoint, values = adapter.match(method=method)
+        except WzNotFound:
+            raise NotFoundError("No route matches {}".format(path))
+        except WzMethodNotAllowed as exc:
+            allowed = ", ".join(sorted(exc.valid_methods or []))
+            raise MethodNotAllowedError(
+                "Method {} not allowed on {}. Allowed: {}".format(
+                    method, path, allowed or "(none)"))
         return endpoint, values
 
     def url_for(self, endpoint, **options):


### PR DESCRIPTION
## Summary

Two related fixes to the routing layer that today surface as unhelpful HTTP 500 responses (or worse, silent empty 200 bodies):

1. `Router.match` catches werkzeug's `NotFound` and `MethodNotAllowed` and re-raises them as typed `NotFoundError` / `MethodNotAllowedError`, so the client sees HTTP 404 / 405 with a clear message.
2. `API.dispatch` raises `NotFoundError` when no registered router matches, instead of falling off the end of the loop and returning `None` (which the JSON serializer turned into an empty HTTP 200 body).

## Depends on

#29 (APIError hierarchy) and #30 (swappable handler). Merge those first.

## Router.match

Werkzeug's `MapAdapter.match(method=method)` raises:

- `werkzeug.exceptions.NotFound` when no rule matches the path
- `werkzeug.exceptions.MethodNotAllowed` when the path matches but the method doesn't

Both used to propagate out of the loop and get wrapped by `handle_errors` as a generic HTTP 500. Now `Router.match` converts them at the boundary:

- `NotFound` → `NotFoundError("No route matches <path>")`
- `MethodNotAllowed` → `MethodNotAllowedError("Method <M> not allowed on <path>. Allowed: <list>")`

The `MethodNotAllowedError` message lists the allowed methods (from `exc.valid_methods`) so the client knows what to try.

## API.dispatch

Previously:

```python
for name, router in component.getUtilitiesFor(IRouter):
    router.initialize(self.context, self.request)
    if router.match(self.context, self.request, path):
        return router(self.context, self.request, path)
# falls off end -> returns None -> empty 200
```

Now:

```python
last_error = None
for name, router in component.getUtilitiesFor(IRouter):
    router.initialize(self.context, self.request)
    try:
        match = router.match(self.context, self.request, path)
    except APIError as exc:
        last_error = exc
        continue
    if match:
        return router(self.context, self.request, path)

if last_error is not None:
    raise last_error
raise NotFoundError("No route matches {}".format(path))
```

Multiple routers still get their chance (one router raising `NotFoundError` doesn't short-circuit the others), and the most recent match failure is what surfaces to the client.

## Backward compatibility

- Clients that were doing `if response.status == 500: ...` to detect "no route" have to switch to `== 404` (the correct status all along).
- No signature changes to public API.

## Stack

1. Add APIError hierarchy and IErrorHandler interface
2. Swappable error handler with clean envelope and status flow
3. **This PR — router 404/405 correctness**
4. Add opt-in CORS support