### PR TITLE
Add opt-in CORS support

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -5,6 +5,7 @@ Changelog
 0.8.0 (unreleased)
 ------------------
 
+- #32 Add opt-in CORS support
 - #31 Convert Router match failures and no-router-matched to typed 404/405
 - #30 Swappable error handler with clean envelope and status flow
 - #29 Add APIError hierarchy and IErrorHandler interface

--- a/src/plone/jsonapi/core/browser/cors.py
+++ b/src/plone/jsonapi/core/browser/cors.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+
+"""Cross-Origin Resource Sharing (CORS) helpers for the JSON API.
+
+Browser-based clients on a different origin (SPA dashboards, static
+sites embedding a widget, integration UIs, ...) cannot call the JSON
+API without CORS response headers. This module exposes:
+
+- `add_cors_headers(request, origin=None, allow_credentials=False,
+  allow_methods=None, allow_headers=None, max_age=None)` -- pure
+  helper that writes the standard Access-Control-* headers on the
+  response.
+
+- `@cors(...)` -- decorator for route view functions that installs
+  the headers on every response and short-circuits OPTIONS preflight
+  requests with a 200 empty body.
+
+Callers pass an `origin` explicitly (or a callable that receives
+the request and returns the allowed origin string, useful for
+policy-driven allow-lists). No implicit `*` -- the caller has to
+opt in.
+"""
+
+import logging
+
+__author__ = "Ramon Bartl <rb@ridingbytes.com>"
+__docformat__ = "plaintext"
+
+logger = logging.getLogger("plone.jsonapi.core.cors")
+
+DEFAULT_ALLOW_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+DEFAULT_ALLOW_HEADERS = (
+    "Accept",
+    "Authorization",
+    "Content-Type",
+    "X-Requested-With",
+)
+
+
+def _resolve_origin(origin, request):
+    """Return the string to send back in Access-Control-Allow-Origin.
+
+    Accepts a plain string (returned as-is), a callable that takes
+    the request and returns a string, or None (no header emitted).
+    """
+    if origin is None:
+        return None
+    if callable(origin):
+        return origin(request)
+    return origin
+
+
+def add_cors_headers(request, origin=None, allow_credentials=False,
+                     allow_methods=None, allow_headers=None,
+                     max_age=None):
+    """Write CORS response headers for the current request.
+
+    :param request: the Zope request whose response gets the headers
+    :param origin: allowed origin string, or callable(request)->str.
+        None means no header is written and the request is treated as
+        same-origin.
+    :param allow_credentials: whether to include
+        Access-Control-Allow-Credentials: true. Note: browsers refuse
+        credentialed requests when the origin header is "*".
+    :param allow_methods: iterable of HTTP methods; defaults to the
+        common REST set including OPTIONS.
+    :param allow_headers: iterable of request header names the client
+        may send; defaults to Accept, Authorization, Content-Type,
+        X-Requested-With.
+    :param max_age: seconds the browser may cache the preflight
+        response; None means no header.
+    """
+    response = getattr(request, "response", None)
+    if response is None:
+        return
+
+    resolved = _resolve_origin(origin, request)
+    if resolved is None:
+        return
+
+    response.setHeader("Access-Control-Allow-Origin", resolved)
+    # Vary: Origin lets caches key by origin so a cached response for
+    # origin A is not served to origin B.
+    response.setHeader("Vary", "Origin")
+
+    if allow_credentials:
+        if resolved == "*":
+            # Browsers reject credentialed requests when origin is *.
+            logger.warning(
+                "CORS allow_credentials=True is incompatible with "
+                "origin='*'; the browser will reject the response.")
+        response.setHeader("Access-Control-Allow-Credentials", "true")
+
+    methods = allow_methods or DEFAULT_ALLOW_METHODS
+    response.setHeader(
+        "Access-Control-Allow-Methods", ", ".join(methods))
+
+    headers = allow_headers or DEFAULT_ALLOW_HEADERS
+    response.setHeader(
+        "Access-Control-Allow-Headers", ", ".join(headers))
+
+    if max_age is not None:
+        response.setHeader("Access-Control-Max-Age", str(int(max_age)))
+
+
+def cors(origin=None, allow_credentials=False, allow_methods=None,
+         allow_headers=None, max_age=None):
+    """Decorator that adds CORS headers to a route response and
+    short-circuits OPTIONS preflight requests.
+
+    Usage::
+
+        @add_route("/things", "things", methods=["GET", "POST"])
+        @cors(origin="https://dashboard.example.com",
+              allow_credentials=True)
+        def things(context, request):
+            return {"items": [...]}
+
+    See `add_cors_headers` for the parameter meaning.
+    """
+    def wrap(func):
+        def decorator(context, request, *args, **kwargs):
+            add_cors_headers(
+                request,
+                origin=origin,
+                allow_credentials=allow_credentials,
+                allow_methods=allow_methods,
+                allow_headers=allow_headers,
+                max_age=max_age,
+            )
+            method = request.environ.get("REQUEST_METHOD", "GET").upper()
+            if method == "OPTIONS":
+                # Preflight: headers were just written; body is empty.
+                return {}
+            return func(context, request, *args, **kwargs)
+        return decorator
+    return wrap

--- a/src/plone/jsonapi/core/tests/test_cors.py
+++ b/src/plone/jsonapi/core/tests/test_cors.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+
+"""Unit tests for the CORS helpers.
+
+Exercises the header-writing helper and the decorator in isolation
+using fake request/response objects, so the tests don't need the
+Plone fixture.
+"""
+
+import unittest2 as unittest
+
+from plone.jsonapi.core.browser.cors import add_cors_headers
+from plone.jsonapi.core.browser.cors import cors
+
+
+class FakeResponse(object):
+    def __init__(self):
+        self.headers = {}
+
+    def setHeader(self, name, value):
+        self.headers[name] = value
+
+
+class FakeRequest(object):
+    def __init__(self, method="GET"):
+        self.response = FakeResponse()
+        self.environ = {"REQUEST_METHOD": method}
+
+
+class TestAddCorsHeaders(unittest.TestCase):
+
+    def test_no_origin_means_no_headers(self):
+        req = FakeRequest()
+        add_cors_headers(req, origin=None)
+        self.assertEqual(req.response.headers, {})
+
+    def test_string_origin_is_written_verbatim(self):
+        req = FakeRequest()
+        add_cors_headers(req, origin="https://app.example.com")
+        self.assertEqual(
+            req.response.headers["Access-Control-Allow-Origin"],
+            "https://app.example.com")
+
+    def test_callable_origin_receives_request(self):
+        req = FakeRequest()
+        captured = []
+
+        def policy(request):
+            captured.append(request)
+            return "https://policy.example.com"
+
+        add_cors_headers(req, origin=policy)
+        self.assertEqual(captured, [req])
+        self.assertEqual(
+            req.response.headers["Access-Control-Allow-Origin"],
+            "https://policy.example.com")
+
+    def test_vary_origin_is_always_set_with_origin(self):
+        req = FakeRequest()
+        add_cors_headers(req, origin="https://a.example.com")
+        self.assertEqual(req.response.headers["Vary"], "Origin")
+
+    def test_default_methods_and_headers(self):
+        req = FakeRequest()
+        add_cors_headers(req, origin="*")
+        self.assertIn("GET", req.response.headers["Access-Control-Allow-Methods"])
+        self.assertIn("POST", req.response.headers["Access-Control-Allow-Methods"])
+        self.assertIn("OPTIONS", req.response.headers["Access-Control-Allow-Methods"])
+        self.assertIn("Authorization", req.response.headers["Access-Control-Allow-Headers"])
+        self.assertIn("Content-Type", req.response.headers["Access-Control-Allow-Headers"])
+
+    def test_custom_methods_and_headers(self):
+        req = FakeRequest()
+        add_cors_headers(
+            req,
+            origin="*",
+            allow_methods=["GET"],
+            allow_headers=["X-Custom"],
+        )
+        self.assertEqual(
+            req.response.headers["Access-Control-Allow-Methods"], "GET")
+        self.assertEqual(
+            req.response.headers["Access-Control-Allow-Headers"], "X-Custom")
+
+    def test_allow_credentials(self):
+        req = FakeRequest()
+        add_cors_headers(
+            req, origin="https://app.example.com", allow_credentials=True)
+        self.assertEqual(
+            req.response.headers["Access-Control-Allow-Credentials"], "true")
+
+    def test_max_age_is_serialized_as_string(self):
+        req = FakeRequest()
+        add_cors_headers(req, origin="*", max_age=600)
+        self.assertEqual(
+            req.response.headers["Access-Control-Max-Age"], "600")
+
+    def test_no_request_context_does_not_crash(self):
+        # add_cors_headers must not raise if it can't find a response.
+        class _NoResp(object):
+            pass
+        add_cors_headers(_NoResp(), origin="*")
+
+
+class TestCorsDecorator(unittest.TestCase):
+
+    def test_get_response_carries_headers_and_calls_view(self):
+        req = FakeRequest("GET")
+        called = []
+
+        @cors(origin="https://app.example.com")
+        def view(context, request):
+            called.append(True)
+            return {"items": []}
+
+        result = view(None, req)
+        self.assertEqual(result, {"items": []})
+        self.assertEqual(called, [True])
+        self.assertEqual(
+            req.response.headers["Access-Control-Allow-Origin"],
+            "https://app.example.com")
+
+    def test_options_preflight_short_circuits(self):
+        req = FakeRequest("OPTIONS")
+        called = []
+
+        @cors(origin="https://app.example.com")
+        def view(context, request):
+            called.append(True)
+            return {"should not": "be called"}
+
+        result = view(None, req)
+        self.assertEqual(result, {})
+        self.assertEqual(called, [])
+        self.assertIn(
+            "Access-Control-Allow-Origin", req.response.headers)
+        self.assertIn(
+            "Access-Control-Allow-Methods", req.response.headers)
+
+    def test_no_origin_means_no_headers_but_view_still_runs(self):
+        req = FakeRequest("GET")
+
+        @cors(origin=None)
+        def view(context, request):
+            return {"ok": True}
+
+        self.assertEqual(view(None, req), {"ok": True})
+        self.assertEqual(req.response.headers, {})
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestAddCorsHeaders))
+    suite.addTest(makeSuite(TestCorsDecorator))
+    return suite


### PR DESCRIPTION
## Summary

Adds Cross-Origin Resource Sharing support so browser-based clients on a different origin (SPA dashboards, static sites embedding a widget, integration UIs, …) can call the JSON API. The framework has been unusable from a different origin without a reverse-proxy hack; `plone.restapi` has CORS built in and this is the same feature at the `plone.jsonapi.core` layer.

## What this PR adds

**`browser/cors.py`** — new module:

- `add_cors_headers(request, origin=None, allow_credentials=False, allow_methods=None, allow_headers=None, max_age=None)` — pure helper that writes the standard `Access-Control-*` headers on the response. Accepts a plain string, a callable `(request) -> str` for policy-driven allow-lists, or `None` to opt out. Always writes `Vary: Origin` alongside so caches key by origin.
- `@cors(...)` decorator — installs the headers on every response and short-circuits OPTIONS preflight requests with an empty 200 body.

## Usage

```python
from plone.jsonapi.core import router
from plone.jsonapi.core.browser.cors import cors


@router.add_route("/things", "things", methods=["GET", "POST", "OPTIONS"])
@cors(origin="https://dashboard.example.com", allow_credentials=True)
def things(context, request):
    return {"items": [...]}
```

## No implicit `*`

Callers pass the origin explicitly. There's no default `Access-Control-Allow-Origin: *` — that avoids the accidental "we shipped an open API" footgun. When a caller does pass `origin="*"` together with `allow_credentials=True` the decorator logs a warning because browsers reject that combination.

## Defaults

- `allow_methods`: `GET, POST, PUT, PATCH, DELETE, OPTIONS`
- `allow_headers`: `Accept, Authorization, Content-Type, X-Requested-With`

Both are overridable per route.

## Backward compatibility

Purely additive. No existing behavior changes; routes that don't opt in are unaffected.

## Coverage

`tests/test_cors.py` covers:

- Helper: no-origin returns no headers, string origin, callable origin (receives the request), `Vary: Origin` always set, default methods/headers, custom methods/headers, credentials flag, max-age serialization, no-response-crash.
- Decorator: GET runs the view + writes headers, OPTIONS short-circuits without calling the view, no-origin doesn't write headers.

## Stack

1. Add APIError hierarchy and IErrorHandler interface
2. Swappable error handler with clean envelope and status flow
3. Convert Router match failures and no-router-matched to typed 404/405
4. **This PR — opt-in CORS support**