### PR TITLE
Make the router thread-safe and dispatch with a single match

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -5,6 +5,7 @@ Changelog
 0.8.0 (unreleased)
 ------------------
 
+- #33 Make the router thread-safe and dispatch with a single match
 - #32 Add opt-in CORS support
 - #31 Convert Router match failures and no-router-matched to typed 404/405
 - #30 Swappable error handler with clean envelope and status flow

--- a/src/plone/jsonapi/core/browser/api.py
+++ b/src/plone/jsonapi/core/browser/api.py
@@ -5,7 +5,7 @@ from .decorators import returns_binary_stream
 from .decorators import returns_json
 from .decorators import returns_xml
 from .decorators import runtime
-from .exceptions import APIError
+from .exceptions import MethodNotAllowedError
 from .exceptions import NotFoundError
 from .interfaces import IAPI
 from .interfaces import IRouter
@@ -43,32 +43,36 @@ class API(BrowserView):
     def dispatch(self):
         """Dispatch the given subpath to the first matching router.
 
-        Router.match raises NotFoundError / MethodNotAllowedError when
-        the path or method does not resolve; earlier versions returned
-        None silently, which surfaced as an empty 200 response. Try
-        each registered router in turn; the first successful match
-        wins. Only the last router's error is reraised, so ordering
-        matters when multiple routers are registered.
+        Each router is asked to `resolve` the path with a single werkzeug
+        match: it returns an (endpoint, values) pair when it handles the
+        path, or None so the next router gets a turn. A resolved router
+        executes the view immediately -- no second match. A
+        MethodNotAllowedError (path matches, method doesn't) is deferred:
+        another router might still fully handle the request, so it is
+        only raised once every router has been tried. NotFoundError is
+        raised when no router matched at all.
         """
         path = "/".join(self.traverse_subpath)
         logger.debug("Dispatching path: '%s'", path)
 
-        last_error = None
+        method_not_allowed = None
         for name, router in component.getUtilitiesFor(IRouter):
             router.initialize(self.context, self.request)
             try:
-                match = router.match(self.context, self.request, path)
-            except APIError as exc:
-                last_error = exc
+                resolved = router.resolve(self.request, path)
+            except MethodNotAllowedError as exc:
+                # Remember it, but let another router try to serve the
+                # method before giving up with a 405.
+                method_not_allowed = exc
                 continue
-            if match:
-                logger.debug("Router '%r' will handle the request", router)
-                return router(self.context, self.request, path)
+            if resolved is None:
+                continue
+            logger.debug("Router '%r' will handle the request", router)
+            endpoint, values = resolved
+            return router.execute(self.context, self.request, endpoint, values)
 
-        # No router matched: reraise the most-recent match failure, or
-        # a bare NotFoundError if none of the routers even threw.
-        if last_error is not None:
-            raise last_error
+        if method_not_allowed is not None:
+            raise method_not_allowed
         raise NotFoundError("No route matches {}".format(path))
 
     @returns_json

--- a/src/plone/jsonapi/core/browser/router.py
+++ b/src/plone/jsonapi/core/browser/router.py
@@ -30,19 +30,18 @@ class Router(object):
         self.view_functions = {}
         self.url_map = Map()
         self.is_initialized = False
-        self.http_host = ""
 
     def initialize(self, context, request):
-        """ called by the API Framework
+        """Build the route table once from the registered IRouteProvider
+        utilities.
+
+        The router is a process-global singleton shared across request
+        threads, so it deliberately stores NO per-request state. Anything
+        derived from the current request (host, scheme, URL) is read from
+        the thread-local request at call time -- see `get_adapter` and
+        `url_for` -- so concurrent requests on different virtual hosts or
+        schemes cannot clobber each other.
         """
-        logger.debug(
-            "DefaultRouter.initialize: context=%r request=%r" % (context, request)
-        )
-
-        self.environ = request.environ
-        self.http_host = urlsplit(request.get("ACTUAL_URL", "")).netloc
-        self.url = request.getURL()
-
         if self.is_initialized:
             return
 
@@ -97,38 +96,65 @@ class Router(object):
         return self.url_map.add(self.rule_class(rule, endpoint=endpoint, **options))
 
     def get_adapter(self, **options):
-        """ return a new werkzeug map adapter
+        """Return a werkzeug MapAdapter bound to the *current* request's
+        host and scheme.
+
+        Host and scheme are read from the thread-local request on every
+        call rather than cached on the (shared, singleton) router, so
+        concurrent requests on different virtual hosts or schemes cannot
+        clobber each other's URL generation.
 
         default options:
-        (script_name=None, subdomain=None, url_scheme='http', default_method='GET', path_info=None, query_args=None)
-        see: http://werkzeug.pocoo.org/docs/routing/#werkzeug.routing.Map.bind
+        (script_name=None, subdomain=None, url_scheme='http',
+         default_method='GET', path_info=None, query_args=None)
+        see: https://werkzeug.palletsprojects.com/routing/#werkzeug.routing.Map.bind
         """
-        adapter = self.url_map.bind(self.http_host, **options)
-        return adapter
+        request = getRequest()
+        actual_url = request.get("ACTUAL_URL", "") if request else ""
+        parts = urlsplit(actual_url)
+        # Preserve the request scheme so force_external URLs are https
+        # behind TLS instead of always http. Callers may still override.
+        options.setdefault("url_scheme", parts.scheme or "http")
+        return self.url_map.bind(parts.netloc, **options)
 
-    def match(self, context, request, path):
-        """Werkzeug URL matcher.
+    def resolve(self, request, path):
+        """Resolve the path+method to an (endpoint, values) pair.
 
-        Werkzeug raises `NotFound` when no rule matches and
-        `MethodNotAllowed` when the path matches but the method
-        doesn't. Both used to propagate out of `handle_errors` as
-        HTTP 500 with an unhelpful body; convert them to proper
-        typed API errors (404 / 405) so the client sees the right
-        status.
+        Returns None when no rule matches the path (so the caller can
+        try the next router). Raises MethodNotAllowedError when the path
+        matches but the HTTP method does not, so the client gets a 405
+        rather than a misleading 404.
         """
         method = request.environ.get("REQUEST_METHOD", "GET")
-        logger.debug("router.match: method=%s" % method)
+        logger.debug("router.resolve: method=%s path=%s", method, path)
         adapter = self.get_adapter(path_info=path)
         try:
-            endpoint, values = adapter.match(method=method)
+            return adapter.match(method=method)
         except WzNotFound:
-            raise NotFoundError("No route matches {}".format(path))
+            return None
         except WzMethodNotAllowed as exc:
             allowed = ", ".join(sorted(exc.valid_methods or []))
             raise MethodNotAllowedError(
                 "Method {} not allowed on {}. Allowed: {}".format(
                     method, path, allowed or "(none)"))
-        return endpoint, values
+
+    def execute(self, context, request, endpoint, values):
+        """Call the view function registered for the given endpoint."""
+        return self.view_functions[endpoint](context, request, **values)
+
+    def match(self, context, request, path):
+        """Backward-compatible matcher.
+
+        Returns (endpoint, values) or raises NotFoundError when no rule
+        matches / MethodNotAllowedError when the method is wrong. New
+        callers should prefer `resolve`, which returns None on no-match
+        instead of raising, so a single werkzeug match serves both the
+        "does this router handle it?" question and the dispatch.
+        """
+        resolved = self.resolve(request, path)
+        if resolved is None:
+            raise NotFoundError("No route matches {}".format(path))
+        return resolved
 
     def url_for(self, endpoint, **options):
         """ get the url for the endpoint
@@ -141,7 +167,7 @@ class Router(object):
         # XXX: this is all a little bit hacky, especially when it comes to virtual hosting.
 
         request = getRequest()
-        spp = request.physicalPathFromURL(self.url)
+        spp = request.physicalPathFromURL(request.getURL())
 
         # find the API view root
         path = []
@@ -159,10 +185,10 @@ class Router(object):
     def __call__(self, context, request, path):
         """ calls the matching view function for the given path
         """
-        logger.debug("router.__call__: path=%s" % path)
+        logger.debug("router.__call__: path=%s", path)
 
         endpoint, values = self.match(context, request, path)
-        return self.view_functions[endpoint](context, request, **values)
+        return self.execute(context, request, endpoint, values)
 
 
 DefaultRouter = Router()

--- a/src/plone/jsonapi/core/tests/test_router.py
+++ b/src/plone/jsonapi/core/tests/test_router.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+
+"""Unit tests for the Router.
+
+These exercise the router in isolation (no Plone layer needed): the
+adapter binding derives host + scheme from the thread-local request, so
+they use a fake request set via zope.globalrequest.
+"""
+
+import threading
+import unittest2 as unittest
+
+from plone.jsonapi.core.browser.exceptions import MethodNotAllowedError
+from plone.jsonapi.core.browser.exceptions import NotFoundError
+from plone.jsonapi.core.browser.router import Router
+from zope.globalrequest import clearRequest
+from zope.globalrequest import setRequest
+
+
+class FakeRequest(object):
+    """Minimal request stub for adapter binding + resolution."""
+
+    def __init__(self, actual_url="http://nohost/plone/@@API", method="GET"):
+        self._actual_url = actual_url
+        self.environ = {"REQUEST_METHOD": method}
+
+    def get(self, key, default=None):
+        if key == "ACTUAL_URL":
+            return self._actual_url
+        return default
+
+
+def make_router():
+    router = Router()
+    # Register a couple of rules directly (bypassing the IRouteProvider
+    # machinery, which needs the component registry).
+    router.add_url_rule(
+        "/things", endpoint="things",
+        view_func=lambda context, request: {"ok": True},
+        options={"methods": ["GET"]})
+    router.add_url_rule(
+        "/things/<string:id>", endpoint="thing_update",
+        view_func=lambda context, request, id: {"id": id},
+        options={"methods": ["PATCH"]})
+    return router
+
+
+class TestAdapterIsRequestDerived(unittest.TestCase):
+    """#1/#2: host and scheme come from the current request, not from
+    state cached on the shared router singleton."""
+
+    def tearDown(self):
+        clearRequest()
+
+    def test_host_from_current_request(self):
+        router = make_router()
+        setRequest(FakeRequest("http://a.example/plone/@@API"))
+        self.assertEqual(router.get_adapter().server_name, "a.example")
+        # A different request must yield a different host from the same
+        # (singleton) router -- proving nothing is cached on self.
+        setRequest(FakeRequest("http://b.example/plone/@@API"))
+        self.assertEqual(router.get_adapter().server_name, "b.example")
+
+    def test_scheme_from_current_request(self):
+        router = make_router()
+        setRequest(FakeRequest("https://secure.example/plone/@@API"))
+        self.assertEqual(router.get_adapter().url_scheme, "https")
+        setRequest(FakeRequest("http://plain.example/plone/@@API"))
+        self.assertEqual(router.get_adapter().url_scheme, "http")
+
+    def test_adapter_is_thread_local(self):
+        # Two threads binding different hosts concurrently must not see
+        # each other's host. The previous implementation stored
+        # http_host on the singleton, so this could race.
+        router = make_router()
+        results = {}
+
+        # Manual two-thread barrier (threading.Barrier is Python 3 only):
+        # both threads set their request before either binds the adapter,
+        # maximising the chance of a cross-thread clobber if the host were
+        # stored on the shared router.
+        lock = threading.Lock()
+        arrived = [0]
+        ready = threading.Event()
+
+        def worker(host):
+            setRequest(FakeRequest("http://%s/plone/@@API" % host))
+            try:
+                with lock:
+                    arrived[0] += 1
+                    if arrived[0] == 2:
+                        ready.set()
+                ready.wait(timeout=5)
+                results[host] = router.get_adapter().server_name
+            finally:
+                clearRequest()
+
+        t1 = threading.Thread(target=worker, args=("a.example",))
+        t2 = threading.Thread(target=worker, args=("b.example",))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        self.assertEqual(results["a.example"], "a.example")
+        self.assertEqual(results["b.example"], "b.example")
+
+
+class TestResolve(unittest.TestCase):
+    """#3: resolve() returns None on no-match (so callers can try the
+    next router) and raises MethodNotAllowedError on a wrong method."""
+
+    def tearDown(self):
+        clearRequest()
+
+    def test_resolve_returns_endpoint_and_values(self):
+        router = make_router()
+        req = FakeRequest("http://nohost/plone/@@API", method="GET")
+        setRequest(req)
+        endpoint, values = router.resolve(req, "/things")
+        self.assertEqual(endpoint, "things")
+        self.assertEqual(values, {})
+
+    def test_resolve_returns_none_on_no_match(self):
+        router = make_router()
+        req = FakeRequest("http://nohost/plone/@@API", method="GET")
+        setRequest(req)
+        self.assertIsNone(router.resolve(req, "/does-not-exist"))
+
+    def test_resolve_raises_method_not_allowed(self):
+        router = make_router()
+        req = FakeRequest("http://nohost/plone/@@API", method="DELETE")
+        setRequest(req)
+        # /things exists for GET, not DELETE.
+        self.assertRaises(
+            MethodNotAllowedError, router.resolve, req, "/things")
+
+    def test_resolve_captures_path_values(self):
+        router = make_router()
+        req = FakeRequest("http://nohost/plone/@@API", method="PATCH")
+        setRequest(req)
+        endpoint, values = router.resolve(req, "/things/abc")
+        self.assertEqual(endpoint, "thing_update")
+        self.assertEqual(values, {"id": "abc"})
+
+
+class TestMatchBackwardCompat(unittest.TestCase):
+    """match() keeps its raising contract for existing callers."""
+
+    def tearDown(self):
+        clearRequest()
+
+    def test_match_raises_not_found(self):
+        router = make_router()
+        req = FakeRequest("http://nohost/plone/@@API", method="GET")
+        setRequest(req)
+        self.assertRaises(
+            NotFoundError, router.match, None, req, "/nope")
+
+    def test_match_returns_tuple_on_hit(self):
+        router = make_router()
+        req = FakeRequest("http://nohost/plone/@@API", method="GET")
+        setRequest(req)
+        endpoint, values = router.match(None, req, "/things")
+        self.assertEqual(endpoint, "things")
+
+    def test_call_executes_view(self):
+        router = make_router()
+        req = FakeRequest("http://nohost/plone/@@API", method="PATCH")
+        setRequest(req)
+        result = router(None, req, "/things/xyz")
+        self.assertEqual(result, {"id": "xyz"})
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestAdapterIsRequestDerived))
+    suite.addTest(makeSuite(TestResolve))
+    suite.addTest(makeSuite(TestMatchBackwardCompat))
+    return suite


### PR DESCRIPTION
## Summary

The `DefaultRouter` is a process-global singleton shared across request threads, but `initialize()` wrote per-request data onto it on every request (`self.environ`, `self.http_host`, `self.url`). `get_adapter()` then read `self.http_host` and `url_for()` read `self.url`, so two concurrent requests on different virtual hosts could clobber each other — request A could generate URLs for request B's host. This PR fixes that plus two adjacent issues.

## 1. Thread safety (the real bug)

The router no longer stores any per-request state. `get_adapter()` and `url_for()` read the host (and URL) from the thread-local request via `getRequest()` on every call, so concurrent requests cannot interfere. The dead `self.environ` assignment — written on every request, read nowhere in the package — is removed.

## 2. URL scheme

`get_adapter()` now binds the werkzeug adapter with the request's actual scheme, so `force_external` URLs come out `https` behind TLS instead of always `http`.

## 3. Single match per request

`dispatch()` previously called `router.match()` to test for a hit, then called `router()` again — which matched a second time. Every request matched twice. New `Router.resolve()` performs one werkzeug match and returns `(endpoint, values)` or `None` (no raise on no-match); `dispatch()` executes the resolved view directly via `Router.execute()`.

A `MethodNotAllowedError` is deferred across routers so another router can still serve the method before a 405 is returned (preserving the previous multi-router semantics). `match()` and `__call__()` are kept — reimplemented on top of `resolve`/`execute` — for backward compatibility.

## Backward compatibility

- `get_adapter(**options)` — signature unchanged; callers can still pass `url_scheme`/`script_name` (they override the request-derived defaults).
- `match(context, request, path)` and `__call__(context, request, path)` — unchanged contracts (match still raises `NotFoundError`/`MethodNotAllowedError`).
- New public methods: `resolve(request, path)` and `execute(context, request, endpoint, values)`.

## Coverage

New `test_router`:

- host derived from the current request (two different requests → two different bound hosts from the same singleton)
- scheme derived from the current request (https vs http)
- two-thread concurrency check (each thread's adapter keeps its own host)
- `resolve()` returns `(endpoint, values)` on a hit, `None` on no-match, raises `MethodNotAllowedError` on a wrong method, and captures path values
- `match()`/`__call__()` retain their raising/execute behavior

All existing unit suites (`test_exceptions`, `test_error_handler`, `test_cors`) still pass.

## Stack

Independent of the CORS/error/hierarchy PRs already merged; targets `master`.