### PR TITLE
Let the API receive PUT/PATCH/DELETE (WebDAV verb bypass)

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -5,6 +5,7 @@ Changelog
 0.8.0 (unreleased)
 ------------------
 
+- #34 Let the API receive PUT/PATCH/DELETE (WebDAV verb bypass)
 - #32 Add opt-in CORS support
 - #31 Convert Router match failures and no-router-matched to typed 404/405
 - #30 Swappable error handler with clean envelope and status flow

--- a/src/plone/jsonapi/core/browser/configure.zcml
+++ b/src/plone/jsonapi/core/browser/configure.zcml
@@ -25,4 +25,10 @@
         provides=".interfaces.IErrorHandler"
         component=".decorators.default_error_handler" />
 
+    <!-- Clear maybe_webdav_client for API requests so PUT/PATCH/DELETE
+         reach the API view instead of Zope's WebDAV machinery. -->
+    <subscriber
+        for="ZPublisher.interfaces.IPubStart"
+        handler=".webdav.allow_api_verbs" />
+
 </configure>

--- a/src/plone/jsonapi/core/browser/webdav.py
+++ b/src/plone/jsonapi/core/browser/webdav.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+"""Let the JSON API receive PUT / PATCH / DELETE.
+
+Zope decides very early in publishing -- in `BaseRequest.traverse`,
+before the API view is ever reached -- whether a non-GET/POST request
+is a WebDAV client, by reading `request.maybe_webdav_client`. When that
+flag is set, ZPublisher may substitute a WebDAV `NullResource` at path
+exhaustion, so the request never reaches the API view and PUT/PATCH/
+DELETE effectively cannot be routed.
+
+The flag is consumed before traversal, so it cannot be cleared from the
+view itself. The only hook that runs early enough is an `IPubStart`
+subscriber. We clear the flag for requests addressed to the API view,
+identified by an `@@API` (or acquisition-form `API`) path segment, so
+the router can dispatch these verbs. Genuine WebDAV requests to other
+content are untouched -- the flag is only cleared for API URLs.
+
+This mirrors the technique `plone.rest` uses for the same purpose.
+"""
+
+import logging
+
+__author__ = "Ramon Bartl <rb@ridingbytes.com>"
+__docformat__ = "plaintext"
+
+logger = logging.getLogger("plone.jsonapi.core.webdav")
+
+# Verbs ZPublisher would otherwise hand to the WebDAV machinery instead
+# of the API view.
+WEBDAV_VERBS = frozenset(["PUT", "PATCH", "DELETE"])
+
+# Path segments that identify a request bound for the API view. The
+# view is registered as @@API and reachable either explicitly (@@API)
+# or via acquisition (API); this matches the same marker the router
+# uses when building URLs.
+API_SEGMENTS = frozenset(["@@API", "API"])
+
+
+def is_api_request(path_info):
+    """True if any path segment marks this as an API-view request."""
+    segments = path_info.split("/")
+    return bool(API_SEGMENTS.intersection(segments))
+
+
+def allow_api_verbs(event):
+    """IPubStart subscriber: clear maybe_webdav_client for API requests
+    using PUT/PATCH/DELETE so they reach the API view.
+    """
+    request = event.request
+    method = request.get("REQUEST_METHOD", "GET").upper()
+    if method not in WEBDAV_VERBS:
+        return
+    path_info = request.get("PATH_INFO", "") or ""
+    if is_api_request(path_info):
+        logger.debug(
+            "Clearing maybe_webdav_client for API %s %s", method, path_info)
+        request.maybe_webdav_client = 0

--- a/src/plone/jsonapi/core/tests/test_webdav.py
+++ b/src/plone/jsonapi/core/tests/test_webdav.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+
+"""Unit tests for the WebDAV verb bypass subscriber."""
+
+import unittest2 as unittest
+
+from plone.jsonapi.core.browser.webdav import allow_api_verbs
+from plone.jsonapi.core.browser.webdav import is_api_request
+
+
+class FakeRequest(object):
+    def __init__(self, method="GET", path_info="/"):
+        self._data = {"REQUEST_METHOD": method, "PATH_INFO": path_info}
+        # Zope's default; the subscriber may flip it to 0.
+        self.maybe_webdav_client = 1
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+
+class FakeEvent(object):
+    def __init__(self, request):
+        self.request = request
+
+
+class TestIsApiRequest(unittest.TestCase):
+
+    def test_matches_explicit_view_segment(self):
+        self.assertTrue(is_api_request("/plone/@@API/senaite/v1/x"))
+
+    def test_matches_acquisition_form_segment(self):
+        self.assertTrue(is_api_request("/plone/API/senaite/v1/x"))
+
+    def test_no_match_for_plain_content(self):
+        self.assertFalse(is_api_request("/plone/clients/client-1"))
+
+    def test_no_substring_false_positive(self):
+        # "APIfolder" is not the "API" segment.
+        self.assertFalse(is_api_request("/plone/APIfolder/doc"))
+
+
+class TestAllowApiVerbs(unittest.TestCase):
+
+    def test_patch_to_api_clears_flag(self):
+        req = FakeRequest("PATCH", "/plone/@@API/senaite/v1/uid")
+        allow_api_verbs(FakeEvent(req))
+        self.assertEqual(req.maybe_webdav_client, 0)
+
+    def test_put_to_api_clears_flag(self):
+        req = FakeRequest("PUT", "/plone/@@API/senaite/v1/uid")
+        allow_api_verbs(FakeEvent(req))
+        self.assertEqual(req.maybe_webdav_client, 0)
+
+    def test_delete_to_api_clears_flag(self):
+        req = FakeRequest("DELETE", "/plone/@@API/senaite/v1/uid")
+        allow_api_verbs(FakeEvent(req))
+        self.assertEqual(req.maybe_webdav_client, 0)
+
+    def test_get_is_untouched(self):
+        req = FakeRequest("GET", "/plone/@@API/senaite/v1/uid")
+        allow_api_verbs(FakeEvent(req))
+        self.assertEqual(req.maybe_webdav_client, 1)
+
+    def test_post_is_untouched(self):
+        req = FakeRequest("POST", "/plone/@@API/senaite/v1/uid")
+        allow_api_verbs(FakeEvent(req))
+        self.assertEqual(req.maybe_webdav_client, 1)
+
+    def test_put_to_non_api_is_untouched(self):
+        # A genuine WebDAV PUT to content must keep its flag so real
+        # WebDAV keeps working.
+        req = FakeRequest("PUT", "/plone/clients/client-1")
+        allow_api_verbs(FakeEvent(req))
+        self.assertEqual(req.maybe_webdav_client, 1)
+
+
+def test_suite():
+    from unittest import TestSuite, makeSuite
+    suite = TestSuite()
+    suite.addTest(makeSuite(TestIsApiRequest))
+    suite.addTest(makeSuite(TestAllowApiVerbs))
+    return suite


### PR DESCRIPTION
## Summary

Zope's publisher decides, in `BaseRequest.traverse` and **before the API view is reached**, whether a non-GET/POST request is a WebDAV client, by reading `request.maybe_webdav_client`. When that flag is set, ZPublisher can substitute a WebDAV `NullResource` at path exhaustion, so `PUT`/`PATCH`/`DELETE` may never reach the API view and cannot be routed.

Because the flag is consumed before traversal, it cannot be cleared from the view itself. The only hook that runs early enough is an `IPubStart` subscriber. This PR adds one that clears the flag for API requests, so consumers can register `PUT`/`PATCH`/`DELETE` routes and have them dispatched. It mirrors the technique `plone.rest` uses for the same purpose.

## Why this is needed even though some views already work

A view that consumes its whole subpath and returns `self` (an `IPublishTraverse` view) happens to receive these verbs already, because at path exhaustion the published object is the view — which has no `PUT`/`PATCH` attribute and does not trip the `NullResource` substitution. But that is incidental to that view's shape and to the client's User-Agent (`maybe_webdav_client` also depends on the User-Agent). This subscriber makes the behavior explicit and robust for **any** `plone.jsonapi.core` consumer and any client.

## Scope (deliberately narrow)

- Only `PUT`/`PATCH`/`DELETE` are considered — `GET`/`POST` already work.
- Only requests whose path contains an `@@API` (or acquisition-form `API`) **segment** are touched, matching the marker the router already uses when building URLs.
- Segment matching, not substring, so `/plone/APIfolder/doc` is not a false positive.
- Genuine WebDAV `PUT`/`PATCH`/`DELETE` to other content keep their flag — real WebDAV is unaffected.

## Coverage

New `test_webdav`:

- `is_api_request`: matches `@@API` and `API` segments, rejects plain content, rejects the `APIfolder` substring false-positive.
- `allow_api_verbs`: PUT/PATCH/DELETE to an API path clear the flag; GET/POST are untouched; PUT to non-API content is untouched.

All existing unit suites still pass.

## Notes

- The subscriber is registered on `ZPublisher.interfaces.IPubStart`.
- If `plone.rest` is also installed, both subscribers may run; setting `maybe_webdav_client = 0` twice is idempotent.

## Stack

Independent of #33 (router thread-safety); targets `master`.