### PR TITLE
Drop simplejson (use stdlib json); pin werkzeug/dicttoxml to last py2.7 releases

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -26,3 +26,6 @@ scripts = zopepy
 # versions need to match the versions in requirements.txt
 setuptools = 44.1.1
 zc.buildout = 2.13.8
+# last Python 2.7-compatible releases (2.x / newer drop py2.7)
+werkzeug = 1.0.1
+dicttoxml = 1.7.4

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -5,7 +5,8 @@ Changelog
 0.8.0 (unreleased)
 ------------------
 
-- #35 Pre-0.8.0 cleanup: remove obsolete JSONP helper, fix logger name, trim /version, declare simplejson/six deps, refresh README, bump packaging pins, drop Travis, add flake8 config
+- #38 Drop simplejson (use stdlib json); pin werkzeug/dicttoxml to last py2.7 releases
+- #35 Pre-0.8.0 cleanup: remove obsolete JSONP helper, fix logger name, trim /version, declare six dep, refresh README, bump packaging pins, drop Travis, add flake8 config
 - #33 Make the router thread-safe and dispatch with a single match
 - #34 Let the API receive PUT/PATCH/DELETE (WebDAV verb bypass)
 - #32 Add opt-in CORS support

--- a/setup.py
+++ b/setup.py
@@ -46,9 +46,10 @@ setup(
     install_requires=[
         "setuptools",
         "six",
-        "werkzeug",
-        "dicttoxml",
-        "simplejson",
+        # werkzeug 2.x and newer dicttoxml drop Python 2.7 support; cap
+        # to the last releases that still install on py2.7.
+        "werkzeug <2.0",
+        "dicttoxml <=1.7.4",
     ],
     extras_require={"test": ["plone.app.testing", "unittest2"]},
     entry_points="""

--- a/src/plone/jsonapi/core/browser/decorators.py
+++ b/src/plone/jsonapi/core/browser/decorators.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
+import json
 import logging
 import os
 import time
 
 import dicttoxml
-import simplejson as json
 from ZPublisher.Iterators import filestream_iterator
 from zope.component import queryUtility
 

--- a/src/plone/jsonapi/core/tests/base.py
+++ b/src/plone/jsonapi/core/tests/base.py
@@ -9,8 +9,8 @@ from plone.testing import z2
 from plone.testing.z2 import Browser
 from zope.configuration import xmlconfig
 
+import json
 import os
-import simplejson as json
 import unittest2 as unittest
 
 


### PR DESCRIPTION
Follow-up to #35 (which merged before these changes were pushed). Two dependency cleanups.

## Drop simplejson

`decorators.py` and the test base used `import simplejson as json`. simplejson is a 2012-era leftover from when the stdlib `json` was immature; for `dumps(dict)` / `loads` it is fully equivalent on this package's targets (Python 2.7 and 3.8). Route providers return plain JSON types; the extra types simplejson can serialize (Decimal, namedtuple) are not used here and remain the consumer's responsibility. Switched both to the standard library `json` and removed `simplejson` from `install_requires`.

## Pin werkzeug / dicttoxml to the last Python 2.7-compatible releases

An unpinned `werkzeug` made buildout try to fetch the latest (3.x), which is Python 3-only — no py2.7 distribution exists, so the download produced zero files and buildout crashed with `need more than 0 values to unpack`. werkzeug 2.0 and newer dicttoxml drop py2.7.

- `install_requires`: cap `werkzeug <2.0` and `dicttoxml <=1.7.4` (caps rather than `==`, so they don't clash with a consumer buildout's own pin).
- Standalone `buildout.cfg [versions]`: pin `werkzeug = 1.0.1`, `dicttoxml = 1.7.4`.

(Consuming buildouts should also pin these in their own `[versions]`; the SENAITE buildout does.)

## Verify

```
Ran 47 tests, 0 failures, 0 errors
flake8 src/plone/jsonapi/core/ setup.py   # clean
```

Targets `master`. Last dependency change before tagging 0.8.0.