### PR TITLE
Strengthen tests and handle errors in XML responses

### DIFF
--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -5,6 +5,7 @@ Changelog
 0.8.0 (unreleased)
 ------------------
 
+- #40 Strengthen tests and handle errors in XML responses
 - #38 Drop simplejson (use stdlib json); pin werkzeug/dicttoxml to last py2.7 releases
 - #35 Pre-0.8.0 cleanup: remove obsolete JSONP helper, fix logger name, trim /version, declare six dep, refresh README, bump packaging pins, drop Travis, add flake8 config
 - #33 Make the router thread-safe and dispatch with a single match

--- a/src/plone/jsonapi/core/browser/api.py
+++ b/src/plone/jsonapi/core/browser/api.py
@@ -83,10 +83,16 @@ class API(BrowserView):
 
     @returns_binary_stream
     def to_binary_stream(self):
+        # NOTE: no @handle_errors here -- the error envelope is a dict,
+        # which cannot be turned into a binary file stream. Errors in a
+        # binary route surface as a normal Zope error response.
         return self.dispatch()
 
     @returns_xml
+    @handle_errors
     def to_xml(self):
+        # handle_errors returns the error envelope as a dict, which
+        # returns_xml renders as XML just like a normal result.
         return self.dispatch()
 
     def __call__(self):

--- a/src/plone/jsonapi/core/docs/Readme.txt
+++ b/src/plone/jsonapi/core/docs/Readme.txt
@@ -68,6 +68,48 @@ Check what happenss when a route throws an Error::
     >>> json.loads(browser.contents).get("message")
     'This failed badly'
 
+The error envelope also carries the exception class name in `type`::
+
+    >>> json.loads(browser.contents).get("type")
+    'RuntimeError'
+
+
+Testing the framework -- PUT, PATCH and DELETE routes::
+
+    >>> @router.add_route("/verb", "verb",
+    ...                   methods=["PUT", "PATCH", "DELETE"])
+    ... def verb(context, request):
+    ...     return {"method": request.get("REQUEST_METHOD")}
+
+    >>> resp = browser.testapp.put(api_url + "/verb", expect_errors=True)
+    >>> resp.status_int
+    200
+    >>> json.loads(resp.body).get("method")
+    'PUT'
+
+    >>> resp = browser.testapp.patch(api_url + "/verb", expect_errors=True)
+    >>> json.loads(resp.body).get("method")
+    'PATCH'
+
+    >>> resp = browser.testapp.delete(api_url + "/verb", expect_errors=True)
+    >>> json.loads(resp.body).get("method")
+    'DELETE'
+
+
+An unknown route returns a 404::
+
+    >>> resp = browser.testapp.get(api_url + "/no/such/route",
+    ...                            expect_errors=True)
+    >>> resp.status_int
+    404
+
+
+A wrong method on a known route returns a 405::
+
+    >>> resp = browser.testapp.post(api_url + "/verb", "", expect_errors=True)
+    >>> resp.status_int
+    405
+
 
 Test XML::
 

--- a/src/plone/jsonapi/core/tests/test_error_handler.py
+++ b/src/plone/jsonapi/core/tests/test_error_handler.py
@@ -13,6 +13,9 @@ from plone.jsonapi.core.browser.decorators import default_error_handler
 from plone.jsonapi.core.browser.decorators import handle_errors
 from plone.jsonapi.core.browser.exceptions import APIError
 from plone.jsonapi.core.browser.exceptions import NotFoundError
+from plone.jsonapi.core.browser.interfaces import IErrorHandler
+from zope.component import getGlobalSiteManager
+from zope.component import provideUtility
 
 
 class FakeResponse(object):
@@ -111,9 +114,59 @@ class TestHandleErrorsDecorator(unittest.TestCase):
         self.assertEqual(view.request.response.status, 500)
 
 
+class TestErrorHandlerIsSwappable(unittest.TestCase):
+    """handle_errors must use a consumer-registered IErrorHandler utility
+    instead of the default, without any monkey-patching."""
+
+    def tearDown(self):
+        # Remove any IErrorHandler registered by a test so the default
+        # (None -> default_error_handler) is restored for other tests.
+        getGlobalSiteManager().unregisterUtility(provided=IErrorHandler)
+
+    def _fake_view(self):
+        class View(object):
+            request = FakeRequest()
+        return View()
+
+    def test_registered_utility_overrides_the_default(self):
+        calls = []
+
+        def custom_handler(exc, request):
+            calls.append((exc, request))
+            return {"handled_by": "custom", "message": str(exc)}
+
+        provideUtility(custom_handler, IErrorHandler)
+
+        view = self._fake_view()
+
+        @handle_errors
+        def raiser(self):
+            raise NotFoundError("gone")
+
+        result = raiser(view)
+        self.assertEqual(result, {"handled_by": "custom", "message": "gone"})
+        self.assertEqual(len(calls), 1)
+        # The exception and the view's request are passed through.
+        self.assertIsInstance(calls[0][0], NotFoundError)
+        self.assertIs(calls[0][1], view.request)
+
+    def test_falls_back_to_default_when_no_utility(self):
+        # With nothing registered, the built-in envelope is produced.
+        view = self._fake_view()
+
+        @handle_errors
+        def raiser(self):
+            raise NotFoundError("gone")
+
+        result = raiser(view)
+        self.assertEqual(result["type"], "NotFoundError")
+        self.assertFalse(result["success"])
+
+
 def test_suite():
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(TestDefaultErrorHandler))
     suite.addTest(makeSuite(TestHandleErrorsDecorator))
+    suite.addTest(makeSuite(TestErrorHandlerIsSwappable))
     return suite

--- a/src/plone/jsonapi/core/tests/test_setup.py
+++ b/src/plone/jsonapi/core/tests/test_setup.py
@@ -11,6 +11,12 @@ class TestSetup(APITestCase):
     def test_version(self):
         self.assertEqual(router.url_for("apiversion"), "/plone/@@API/version")
 
+    def test_url_for_force_external(self):
+        # force_external must return an absolute URL for the current host.
+        url = router.url_for("apiversion", force_external=True)
+        self.assertTrue(url.startswith("http://"), url)
+        self.assertTrue(url.endswith("/@@API/version"), url)
+
 
 def test_suite():
     from unittest import TestSuite, makeSuite


### PR DESCRIPTION
Closes the test-coverage gaps found in the pre-0.8.0 review, plus one code fix.

## Test coverage added

- **IErrorHandler swappability** (`test_error_handler`): registers a custom `IErrorHandler` utility and asserts `handle_errors` uses it instead of the default — the headline of the swappable-handler design was previously untested — plus the fallback-to-default path.
- **REST verbs end-to-end** (`docs/Readme.txt`): drives real `PUT`/`PATCH`/`DELETE` through the API view, validating the WebDAV bypass + router method routing together (previously only unit/fake-event level).
- **404 / 405 at the HTTP level** (`docs/Readme.txt`): unknown route → 404, wrong method on a known route → 405 (previously only `resolve()` was unit-tested).
- **Error envelope `type`**: the `/fail` doctest now also asserts `type == "RuntimeError"`.
- **`url_for(force_external=True)`** (`test_setup`): returns an absolute URL — the fragile external / virtual-hosting path had no coverage.

## Code fix

- `to_xml` now runs under `@handle_errors`, so an exception in an XML route returns the error envelope rendered as XML instead of a raw Zope 500. `to_binary_stream` deliberately keeps raw errors (the envelope is a dict and cannot become a file stream) — documented inline.

## Verification status

- The `IErrorHandler` tests run in the **unit suite** and are verified green here (49 unit tests, 0 failures; flake8 clean).
- The REST-verb, 404/405, `type`-field and `force_external` tests need the **Plone test layer** (`bin/test-externals -s plone.jsonapi.core`) — I could not execute those in this environment, so please run them once before merge.

## Remaining known gap (not in this PR)

**No CI.** With Travis removed there is no automated gate, and py3.8 is never actually exercised (all local runs are py2.7). A GitHub Actions workflow is the fix, but py2.7 CI is non-trivial and I did not want to add an unverified workflow — flagging it for a decision.

Targets `master`.