### PR TITLE
Add GitHub Actions CI (lint + py2.7/py3.8 tests)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,58 @@
+name: tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install flake8
+        run: python -m pip install flake8
+      - name: Lint
+        run: flake8 src/plone/jsonapi/core setup.py
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Python 2.7 needs a container: GitHub runners no longer ship
+          # it. The 2.7 image is Debian buster (old glibc), so the
+          # container steps pin to action versions that still run there.
+          - python: "2.7"
+            image: "python:2.7-buster"
+          - python: "3.8"
+            image: "python:3.8-bullseye"
+    container: ${{ matrix.image }}
+    steps:
+      - name: Checkout
+        # v3 (node16) runs on the older glibc of the py2.7 image; v4
+        # (node20) does not.
+        uses: actions/checkout@v3
+
+      - name: Cache eggs
+        uses: actions/cache@v3
+        with:
+          path: eggs
+          key: eggs-${{ matrix.python }}-${{ hashFiles('requirements.txt', 'buildout.cfg') }}
+          restore-keys: |
+            eggs-${{ matrix.python }}-
+
+      - name: Install bootstrap toolchain
+        run: python -m pip install -r requirements.txt
+
+      - name: Buildout
+        run: buildout -N -c buildout.cfg
+
+      - name: Run tests
+        run: bin/test -v1

--- a/src/plone/jsonapi/core/docs/Readme.txt
+++ b/src/plone/jsonapi/core/docs/Readme.txt
@@ -42,8 +42,8 @@ Testing the framework -- lets add a new GET route::
     ...     return dict(hello=name)
 
     >>> browser.open(api_url + "/hello/world")
-    >>> json.loads(browser.contents).get("hello")
-    'world'
+    >>> print(json.loads(browser.contents).get("hello"))
+    world
 
 
 Testing the framework -- lets add a new POST route::
@@ -53,25 +53,28 @@ Testing the framework -- lets add a new POST route::
     ...     return {"hello": "post"}
 
     >>> browser.post(api_url + "/hello", "")
-    >>> json.loads(browser.contents).get("hello")
-    'post'
+    >>> print(json.loads(browser.contents).get("hello"))
+    post
 
 
-Check what happenss when a route throws an Error::
+Check what happens when a route throws an error. The error handler
+turns it into a JSON envelope with the matching HTTP status (500 for a
+bare exception) instead of leaking a traceback::
 
     >>> @router.add_route("/fail", "fail", methods=["GET"])
     ... def fail(context, request):
     ...     raise RuntimeError("This failed badly")
 
-    >>> browser.open(api_url + "/fail")
-    Traceback ...
-    >>> json.loads(browser.contents).get("message")
-    'This failed badly'
+    >>> resp = browser.testapp.get(api_url + "/fail", expect_errors=True)
+    >>> resp.status_int
+    500
+    >>> print(json.loads(resp.body).get("message"))
+    This failed badly
 
-The error envelope also carries the exception class name in `type`::
+The envelope also carries the exception class name in `type`::
 
-    >>> json.loads(browser.contents).get("type")
-    'RuntimeError'
+    >>> print(json.loads(resp.body).get("type"))
+    RuntimeError
 
 
 Testing the framework -- PUT, PATCH and DELETE routes::
@@ -84,16 +87,16 @@ Testing the framework -- PUT, PATCH and DELETE routes::
     >>> resp = browser.testapp.put(api_url + "/verb", expect_errors=True)
     >>> resp.status_int
     200
-    >>> json.loads(resp.body).get("method")
-    'PUT'
+    >>> print(json.loads(resp.body).get("method"))
+    PUT
 
     >>> resp = browser.testapp.patch(api_url + "/verb", expect_errors=True)
-    >>> json.loads(resp.body).get("method")
-    'PATCH'
+    >>> print(json.loads(resp.body).get("method"))
+    PATCH
 
     >>> resp = browser.testapp.delete(api_url + "/verb", expect_errors=True)
-    >>> json.loads(resp.body).get("method")
-    'DELETE'
+    >>> print(json.loads(resp.body).get("method"))
+    DELETE
 
 
 An unknown route returns a 404::
@@ -117,8 +120,8 @@ Test XML::
     ... def xml(context, request):
     ...     return {"type": "xml"}
     >>> browser.open(api_url + "/xml?asxml=1")
-    >>> browser.contents
-    b'<?xml version="1.0" encoding="UTF-8" ?><root><type type="str">xml</type></root>'
+    >>> print(browser.contents.decode("utf-8"))
+    <?xml version="1.0" encoding="UTF-8" ?><root><type type="str">xml</type></root>
 
 
 Test Binary Stream::
@@ -127,5 +130,5 @@ Test Binary Stream::
     ... def data(context, request):
     ...     return self.get_testfile_path()
     >>> browser.open(api_url + "/data?asbinary=1")
-    >>> browser.contents
-    b'%PDF-...'
+    >>> browser.contents[:5] == b"%PDF-"
+    True

--- a/src/plone/jsonapi/core/tests/base.py
+++ b/src/plone/jsonapi/core/tests/base.py
@@ -50,6 +50,26 @@ INTEGRATION_TESTING = IntegrationTesting(
 class APITestCase(unittest.TestCase):
     layer = INTEGRATION_TESTING
 
+    def setUp(self):
+        super(APITestCase, self).setUp()
+        from zope.globalrequest import setRequest
+        # url_for derives the @@API mount from the *current* request
+        # (via zope.globalrequest). In this minimal layer nothing
+        # publishes an @@API request for the integration tests, so
+        # expose a request whose URL points at the @@API view and make
+        # it the global request. Full Plone wires this up automatically;
+        # here we do it explicitly so url_for can resolve.
+        request = self.layer["request"]
+        api_url = self.getPortal().absolute_url() + "/@@API"
+        request["URL"] = api_url
+        request["ACTUAL_URL"] = api_url
+        setRequest(request)
+
+    def tearDown(self):
+        from zope.globalrequest import clearRequest
+        clearRequest()
+        super(APITestCase, self).tearDown()
+
     def getBrowser(self, handleErrors=False):
         browser = Browser(self.getApp())
         if handleErrors:


### PR DESCRIPTION
Replaces the removed Travis config with GitHub Actions. **All jobs green** (lint + py2.7 + py3.8).

## What it does

- **lint**: flake8 (`max-line-length = 80`) on `src/` + `setup.py`, on py3.11.
- **test** matrix: runs the buildout suite (`bin/test`) on **Python 2.7** and **Python 3.8** against Plone 5.2, using the existing `buildout.cfg` + `requirements.txt`.

py2.7 runs in a `python:2.7-buster` container (hosted runners no longer ship py2.7); `actions/checkout` + `actions/cache` are pinned to v3 (node16) so they run on that image's older glibc. No untrusted inputs are used in `run:` steps.

## Fixes the CI surfaced (and this PR includes)

Turning CI on immediately caught real, previously-invisible breakage — the whole point of adding it:

1. **`url_for` in the test layer.** After #33, `url_for` reads the current request via `zope.globalrequest`; full Plone populates that but this minimal layer did not, so `url_for` returned a bare path (`test_version` had been silently failing since #33, plus the new `test_url_for_force_external` and the version doctest). Fixed by exposing a properly-URL'd `@@API` request in `APITestCase.setUp`/`tearDown`. **Not a production regression** — the live instance builds correct URLs.

2. **Readme doctest was Python 3-only.** It relied on py3 reprs (`'world'`, `b'...'`) and had a malformed `Traceback ...` block for the error route. Rewritten to be version-agnostic (print values, byte-prefix equality, and the WebTest client asserting the 500 status + `message`/`type` envelope). Now passes on both interpreters.

## Not changelogged

CI is dev infrastructure — no HISTORY entry. (The `url_for` fixture + doctest fixes are test-only and likewise not user-facing.)

Targets `master`.