### PR TITLE
Add declarative route permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,3 +290,28 @@ turned into a JSON error envelope with the matching HTTP status:
     "type": "Unauthorized"
 }
 ```
+
+### Declarative permissions
+
+Since 0.8.0 a route can declare its permission instead of checking it by
+hand. Pass `permission` when registering the route and the router
+enforces it on the dispatch context before the endpoint runs: anonymous
+callers get a 401, authenticated-but-unauthorized callers a 403, both as
+the usual JSON error envelope. Routes without a `permission` behave
+exactly as before (no check), so this is fully opt-in:
+
+```python
+from plone.jsonapi.core import router
+
+
+@router.add_route("/hello/<string:name>", "hello", methods=["GET"],
+                  permission="ViewHelloAPI")
+def hello(context, request, name="world"):
+    return {"hello": name}
+```
+
+The same key works in the `IRouteProvider` tuple form via the options
+dict, e.g. `dict(methods=["GET"], permission="ViewHelloAPI")`. Prefer
+this over the manual check above for route-level gating; object-level
+checks (against something resolved inside the endpoint) stay the
+endpoint's responsibility.

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -5,6 +5,7 @@ Changelog
 0.8.0 (unreleased)
 ------------------
 
+- #46 Add declarative route permissions
 - #44 Convert README to Markdown and document the thin-layer / permissions model
 - #40 Strengthen tests and handle errors in XML responses
 - #38 Drop simplejson (use stdlib json); pin werkzeug/dicttoxml to last py2.7 releases

--- a/docs/proposals/0001-declarative-route-permissions.md
+++ b/docs/proposals/0001-declarative-route-permissions.md
@@ -1,0 +1,194 @@
+# Proposal: declarative route permissions
+
+- **Status:** draft
+- **Affects:** `plone.jsonapi.core.browser.router`,
+  `plone.jsonapi.core.browser.api`
+- **Backward compatible:** yes (opt-in; default behavior unchanged)
+
+
+## Problem
+
+`plone.jsonapi.core` bypasses object traversal: the `@@API` view is
+published with the weak `zope2.View` permission (which Anonymous holds
+at the site root), and the request never acquires a content object's
+security context. As a result the framework does **not** authorize
+requests — each route is expected to check permissions itself:
+
+```python
+@router.add_route("/registry", "registry", methods=["GET"])
+def registry(context, request):
+    if not getSecurityManager().checkPermission("cmf.ManagePortal", context):
+        raise Unauthorized("...")
+    return read_registry()
+```
+
+This is a convention, not a guarantee. A route that forgets the check
+is silently reachable by anonymous callers. Authorization bugs of
+exactly this shape (an endpoint exposed without a permission check) are
+the most common and most serious defect class for consumers of this
+framework. Security should be something you *declare* and the framework
+*enforces*, not something every author must remember to hand-write.
+
+
+## Proposal
+
+Add an optional `permission` to a route. When set, the router checks it
+**before** invoking the endpoint and raises the appropriate typed error
+if the caller is not allowed. When unset, behavior is exactly as today.
+
+### API
+
+Decorator form:
+
+```python
+@router.add_route(
+    "/registry", "registry", methods=["GET"],
+    permission="cmf.ManagePortal")
+def registry(context, request):
+    return read_registry()
+```
+
+`IRouteProvider` tuple form (the options dict already flows through):
+
+```python
+@property
+def routes(self):
+    return (
+        ("/registry", "registry", self.registry,
+         dict(methods=["GET"], permission="cmf.ManagePortal")),
+    )
+```
+
+The value is a Zope permission name (a string), the same thing you
+would pass to `getSecurityManager().checkPermission(...)`.
+
+### Behavior
+
+At dispatch time, once a route is resolved and before its endpoint is
+called:
+
+1. If the route declares no `permission`, call the endpoint (current
+   behavior — fully backward compatible).
+2. Otherwise check the permission on the dispatch context:
+   - allowed -> call the endpoint;
+   - denied and the caller is **anonymous** -> raise
+     `UnauthorizedError` (HTTP 401, prompting authentication);
+   - denied and the caller is **authenticated** -> raise
+     `ForbiddenError` (HTTP 403).
+
+Both errors are the existing typed exceptions, so they flow through
+`handle_errors` / `IErrorHandler` into the normal JSON envelope with
+the correct status — no new error plumbing.
+
+The permission is checked against the **dispatch context** (the object
+the `@@API` view was invoked on). This gives a reliable "you need
+permission X to reach this endpoint at all" gate. Object-level checks
+(e.g. against a specific object resolved by UID inside the endpoint)
+remain the endpoint's responsibility; see *Future work*.
+
+
+## Implementation sketch
+
+`permission` is not a Werkzeug `Rule` keyword, so it must be popped from
+the options before the rule is built and stored per endpoint, alongside
+`view_functions`.
+
+`router.py`:
+
+```python
+class Router(object):
+
+    def __init__(self):
+        self.rule_class = Rule
+        self.view_functions = {}
+        self.route_permissions = {}   # endpoint -> permission name
+        self.url_map = Map()
+        self.is_initialized = False
+
+    def add_url_rule(self, rule, endpoint=None, view_func=None, options=None):
+        if endpoint is None:
+            endpoint = view_func.__name__
+        options = dict(options or {})
+        # Extract our own option before handing the rest to Werkzeug.
+        permission = options.pop("permission", None)
+
+        old_func = self.view_functions.get(endpoint)
+        if old_func is not None and old_func != view_func:
+            raise AssertionError(
+                "View function mapping is overwriting an existing "
+                "endpoint function: %s" % endpoint)
+
+        self.view_functions[endpoint] = view_func
+        self.route_permissions[endpoint] = permission
+        return self.url_map.add(
+            self.rule_class(rule, endpoint=endpoint, **options))
+
+    def check_permission(self, endpoint, context):
+        """Enforce the endpoint's declared permission, if any."""
+        permission = self.route_permissions.get(endpoint)
+        if permission is None:
+            return
+        if getSecurityManager().checkPermission(permission, context):
+            return
+        if getSecurityManager().getUser().getUserName() == "Anonymous User":
+            raise UnauthorizedError(
+                "Authentication required for '%s'" % endpoint)
+        raise ForbiddenError(
+            "You do not have the '%s' permission" % permission)
+
+    def execute(self, context, request, endpoint, values):
+        self.check_permission(endpoint, context)
+        return self.view_functions[endpoint](context, request, **values)
+```
+
+(`getSecurityManager` from `AccessControl`; `UnauthorizedError` /
+`ForbiddenError` from `plone.jsonapi.core.browser.exceptions`. The
+anonymous test above is illustrative — `portal_membership.isAnonymousUser()`
+or `zope.security` may be preferred in the real change.)
+
+No change is needed in `api.py`: `dispatch()` already routes through
+`Router.execute`, so the check applies to every dispatched request.
+
+
+## Backward compatibility
+
+- `permission` defaults to `None`; every existing route keeps working
+  with no check, exactly as today.
+- No signature breakage: `permission` is just another key in the
+  `**options` / options dict.
+- Existing manual `checkPermission` calls in endpoints continue to work
+  and can be migrated to the declarative form incrementally.
+
+
+## Migration path
+
+1. Ship the feature (opt-in) as above.
+2. Encourage every non-public route to declare a `permission`; migrate
+   existing manual checks.
+3. Optionally add a router **strict mode** (off by default) that logs a
+   warning — or raises at registration time — for any route that
+   declares no `permission`, so a project can enforce "every route must
+   state its permission" once it has finished migrating.
+
+
+## Future work (out of scope here)
+
+- **Per-object permission context.** Allow a route to declare how to
+  resolve the object the permission is checked against (e.g. a callable
+  `permission_context=lambda context, request, **values: resolve(values["uid"])`),
+  so object-level authorization can also be declarative.
+- **Multiple permissions / roles.** Support a sequence (all-of / any-of)
+  if a route needs more than one permission.
+
+
+## Alternatives considered
+
+- **Keep it a convention (status quo).** Rejected: it has repeatedly
+  produced anonymously-reachable endpoints; the framework should make
+  the safe path the default path.
+- **Register endpoints as ZCA views with a real permission** (the
+  `plone.rest` model). This is the most Zope-idiomatic answer and gets
+  traversal-based security for free, but it is a much larger change that
+  abandons the flat-URL / catalog-first model this package is built
+  around. The declarative option above keeps that model while closing
+  the security gap.

--- a/docs/proposals/0001-declarative-route-permissions.md
+++ b/docs/proposals/0001-declarative-route-permissions.md
@@ -1,8 +1,7 @@
 # Proposal: declarative route permissions
 
-- **Status:** draft
-- **Affects:** `plone.jsonapi.core.browser.router`,
-  `plone.jsonapi.core.browser.api`
+- **Status:** implemented in 0.8.0
+- **Affects:** `plone.jsonapi.core.browser.router`
 - **Backward compatible:** yes (opt-in; default behavior unchanged)
 
 

--- a/src/plone/jsonapi/core/browser/router.py
+++ b/src/plone/jsonapi/core/browser/router.py
@@ -1,8 +1,12 @@
 # -*- coding: utf-8 -*-
 
+from .exceptions import ForbiddenError
 from .exceptions import MethodNotAllowedError
 from .exceptions import NotFoundError
+from .exceptions import UnauthorizedError
 from .interfaces import IRouteProvider
+from AccessControl import getSecurityManager
+from Products.CMFCore.utils import getToolByName
 from six.moves.urllib.parse import urlsplit
 from werkzeug.exceptions import MethodNotAllowed as WzMethodNotAllowed
 from werkzeug.exceptions import NotFound as WzNotFound
@@ -28,6 +32,7 @@ class Router(object):
         logger.debug("DefaultRouter::__init__")
         self.rule_class = Rule
         self.view_functions = {}
+        self.route_permissions = {}
         self.url_map = Map()
         self.is_initialized = False
 
@@ -78,6 +83,13 @@ class Router(object):
         if endpoint is None:
             endpoint = view_func.__name__
 
+        # Extract framework-level options before handing the rest to the
+        # werkzeug Rule, which rejects unknown keywords. `permission` is a
+        # declared Zope permission enforced by `check_permission` at
+        # dispatch; see the declarative-route-permissions proposal.
+        options = dict(options or {})
+        permission = options.pop("permission", None)
+
         old_func = self.view_functions.get(endpoint)
 
         # Avoid route overwriting
@@ -87,13 +99,11 @@ class Router(object):
                 "existing endpoint function: %s" % endpoint
             )
 
-        # Store the view function below the endpoint
+        # Store the view function and its permission below the endpoint
         self.view_functions[endpoint] = view_func
+        self.route_permissions[endpoint] = permission
 
-        if options is None:
-            # http://werkzeug.pocoo.org/docs/routing/#werkzeug.routing.Rule
-            return self.url_map.add(self.rule_class(rule, endpoint=endpoint))
-
+        # http://werkzeug.pocoo.org/docs/routing/#werkzeug.routing.Rule
         return self.url_map.add(
             self.rule_class(rule, endpoint=endpoint, **options))
 
@@ -140,8 +150,48 @@ class Router(object):
                 "Method {} not allowed on {}. Allowed: {}".format(
                     method, path, allowed or "(none)"))
 
+    def check_permission(self, context, endpoint):
+        """Enforce the endpoint's declared permission, if any.
+
+        A route may declare a Zope permission via the `permission`
+        option. When set, the router verifies it on the dispatch context
+        before the endpoint runs:
+
+        - no declared permission -> call the endpoint unchecked (the
+          historical behavior; fully backward compatible);
+        - declared and granted -> call the endpoint;
+        - declared and denied, caller anonymous -> `UnauthorizedError`
+          (401, prompting authentication);
+        - declared and denied, caller authenticated -> `ForbiddenError`
+          (403).
+
+        See the declarative-route-permissions proposal for the rationale.
+        """
+        permission = self.route_permissions.get(endpoint)
+        if permission is None:
+            return
+        if getSecurityManager().checkPermission(permission, context):
+            return
+        if self.is_anonymous(context):
+            raise UnauthorizedError(
+                "Authentication required for '{}'".format(endpoint))
+        raise ForbiddenError(
+            "You do not have the '{}' permission required for "
+            "'{}'".format(permission, endpoint))
+
+    @staticmethod
+    def is_anonymous(context):
+        """True if the current caller is not authenticated."""
+        mtool = getToolByName(context, "portal_membership")
+        return mtool.isAnonymousUser()
+
     def execute(self, context, request, endpoint, values):
-        """Call the view function registered for the given endpoint."""
+        """Call the view function registered for the given endpoint.
+
+        Enforces the endpoint's declared permission (if any) before the
+        view function runs.
+        """
+        self.check_permission(context, endpoint)
         return self.view_functions[endpoint](context, request, **values)
 
     def match(self, context, request, path):

--- a/src/plone/jsonapi/core/tests/test_router.py
+++ b/src/plone/jsonapi/core/tests/test_router.py
@@ -10,8 +10,11 @@ they use a fake request set via zope.globalrequest.
 import threading
 import unittest2 as unittest
 
+from plone.jsonapi.core.browser import router as router_module
+from plone.jsonapi.core.browser.exceptions import ForbiddenError
 from plone.jsonapi.core.browser.exceptions import MethodNotAllowedError
 from plone.jsonapi.core.browser.exceptions import NotFoundError
+from plone.jsonapi.core.browser.exceptions import UnauthorizedError
 from plone.jsonapi.core.browser.router import Router
 from zope.globalrequest import clearRequest
 from zope.globalrequest import setRequest
@@ -172,10 +175,97 @@ class TestMatchBackwardCompat(unittest.TestCase):
         self.assertEqual(result, {"id": "xyz"})
 
 
+class FakeSecurityManager(object):
+    """Grants or denies every permission check uniformly."""
+
+    def __init__(self, allowed):
+        self._allowed = allowed
+
+    def checkPermission(self, permission, context):
+        return self._allowed
+
+
+class FakeMembershipTool(object):
+    """Reports the caller as anonymous or authenticated."""
+
+    def __init__(self, anonymous):
+        self._anonymous = anonymous
+
+    def isAnonymousUser(self):
+        return self._anonymous
+
+
+class TestDeclarativePermissions(unittest.TestCase):
+    """A route may declare a `permission`; the router enforces it before
+    the endpoint runs. Routes without one keep the historical behavior.
+    """
+
+    def setUp(self):
+        # Save the module-level lookups the router uses for security, so
+        # we can stub them without a full Plone security context.
+        self._orig_sm = router_module.getSecurityManager
+        self._orig_gtbn = router_module.getToolByName
+
+    def tearDown(self):
+        router_module.getSecurityManager = self._orig_sm
+        router_module.getToolByName = self._orig_gtbn
+        clearRequest()
+
+    def patch_security(self, allowed, anonymous=False):
+        router_module.getSecurityManager = lambda: FakeSecurityManager(
+            allowed)
+        router_module.getToolByName = lambda context, name: FakeMembershipTool(
+            anonymous)
+
+    def make_guarded_router(self):
+        router = Router()
+        router.add_url_rule(
+            "/admin", endpoint="admin",
+            view_func=lambda context, request: {"ok": True},
+            options={"methods": ["GET"], "permission": "cmf.ManagePortal"})
+        return router
+
+    def test_permission_is_stored_not_passed_to_werkzeug(self):
+        # If `permission` leaked into the werkzeug Rule, add_url_rule
+        # would already have raised; reaching here proves it was popped.
+        router = self.make_guarded_router()
+        self.assertEqual(
+            router.route_permissions["admin"], "cmf.ManagePortal")
+
+    def test_route_without_permission_is_unchecked(self):
+        router = make_router()
+        # No security stubbing: an unguarded route must not touch the
+        # security machinery at all.
+        self.assertEqual(router.route_permissions["things"], None)
+        result = router.execute(None, FakeRequest(), "things", {})
+        self.assertEqual(result, {"ok": True})
+
+    def test_granted_permission_calls_endpoint(self):
+        router = self.make_guarded_router()
+        self.patch_security(allowed=True)
+        result = router.execute(object(), FakeRequest(), "admin", {})
+        self.assertEqual(result, {"ok": True})
+
+    def test_denied_authenticated_raises_forbidden(self):
+        router = self.make_guarded_router()
+        self.patch_security(allowed=False, anonymous=False)
+        self.assertRaises(
+            ForbiddenError,
+            router.execute, object(), FakeRequest(), "admin", {})
+
+    def test_denied_anonymous_raises_unauthorized(self):
+        router = self.make_guarded_router()
+        self.patch_security(allowed=False, anonymous=True)
+        self.assertRaises(
+            UnauthorizedError,
+            router.execute, object(), FakeRequest(), "admin", {})
+
+
 def test_suite():
     from unittest import TestSuite, makeSuite
     suite = TestSuite()
     suite.addTest(makeSuite(TestAdapterIsRequestDerived))
     suite.addTest(makeSuite(TestResolve))
     suite.addTest(makeSuite(TestMatchBackwardCompat))
+    suite.addTest(makeSuite(TestDeclarativePermissions))
     return suite


### PR DESCRIPTION
## Summary

Adds an opt-in, declarative `permission` to routes so the router enforces authorization instead of every endpoint hand-writing a `checkPermission` call. This supersedes #45 (the proposal), which is now included here alongside the implementation, tests and docs so the feature lands as one self-contained PR for 0.8.0.

## Motivation

`plone.jsonapi.core` publishes the `@@API` view with the weak `zope2.View` permission and bypasses object traversal, so the framework does not authorize requests: each route is expected to check permissions itself. That is a convention, not a guarantee. A route that forgets the check is silently reachable by anonymous callers, which is the most common and most serious defect class for consumers of this framework.

## What changes

A route may declare a Zope permission:

```python
from plone.jsonapi.core import router

@router.add_route("/registry", "registry", methods=["GET"],
                  permission="cmf.ManagePortal")
def registry(context, request):
    return read_registry()
```

The same key works in the `IRouteProvider` tuple form via the options dict: `dict(methods=["GET"], permission="cmf.ManagePortal")`.

At dispatch, once a route is resolved and before its endpoint runs:

- no declared `permission` -> call the endpoint unchecked (historical behavior);
- declared and granted -> call the endpoint;
- declared and denied, caller anonymous -> `UnauthorizedError` (401, prompting authentication);
- declared and denied, caller authenticated -> `ForbiddenError` (403).

Both errors are the existing typed exceptions, so they flow through `handle_errors` / `IErrorHandler` into the normal JSON envelope with the correct status. The permission is checked against the dispatch context; object-level checks (against something resolved inside the endpoint) remain the endpoint's responsibility.

## Backward compatibility

Fully backward compatible and opt-in. `permission` defaults to `None`; every existing route keeps working with no check, taking the exact previous code path (verified by tests with a permission-less route and a `None` context, which never touch the security machinery). `permission` is popped from the options before the werkzeug `Rule` is built, so it is not a signature break.

## Implementation

- `router.add_url_rule`: pop `permission` from the options, store it per endpoint in `route_permissions`.
- `router.check_permission` / `router.is_anonymous`: enforce the declared permission on the dispatch context.
- `router.execute`: call `check_permission` before invoking the view function; `dispatch()` already routes through `execute`, so the check applies to every dispatched request.

## Tests

Five new unit tests in `test_router.py`: permission stored (and never passed to werkzeug), unguarded route unchecked, granted -> endpoint runs, denied + authenticated -> 403, denied + anonymous -> 401. Full suite: 57 tests, 0 failures, 0 errors on Python 2.7.

## Docs

- README: new "Declarative permissions" section.
- `docs/HISTORY.rst`: changelog entry.
- `docs/proposals/0001-declarative-route-permissions.md`: status flipped to implemented in 0.8.0.